### PR TITLE
Dual Boot

### DIFF
--- a/Core/Src/gw_flash_alloc.c
+++ b/Core/Src/gw_flash_alloc.c
@@ -210,7 +210,8 @@ static bool circular_flash_write(const char *file_path,
     }
 
     uint32_t old_flash_write_pointer = flash_write_pointer;
-    uint32_t address_in_flash = flash_write_pointer - flash_write_base;
+    // Translates the address to an offset into external flash.
+    uint32_t address_in_flash = flash_write_pointer - (uint32_t)&__EXTFLASH_BASE__;
     uint32_t block_size = OSPI_GetSmallestEraseSize();
 
     OSPI_DisableMemoryMappedMode();

--- a/Core/Src/gw_flash_alloc.c
+++ b/Core/Src/gw_flash_alloc.c
@@ -28,12 +28,25 @@ typedef struct
 typedef struct
 {
     FileMetadata files[MAX_FILES];
-    uint32_t flash_write_pointer;
+    uint32_t flash_write_pointer;  // A value like 0x9YYYYYYY; the current location we should write to.
+    uint32_t flash_write_base;     // A value like 0x9YYYYYYY; the starting point we are allowed to write to.
     uint16_t last_written_slot_index;
 } Metadata;
 
 static Metadata *metadata = NULL;
 static uint32_t flash_write_pointer = 0;
+
+#pragma pack(push, 1)
+typedef struct
+{
+    unsigned int external_flash_size : 24;
+    unsigned int is_mario : 1;
+    unsigned int is_zelda : 1;
+    unsigned int _padding : 6;  // Padding to align to byte boundary
+} Bank1FirmwareMetadata;
+#pragma pack(pop)
+
+Bank1FirmwareMetadata bank1_firmware_metadata;
 
 static uint32_t compute_file_crc32(const char *file_path)
 {
@@ -55,15 +68,50 @@ static uint32_t align_to_next_block(uint32_t pointer)
     return (pointer + block_size - 1) & ~(block_size - 1);
 }
 
+static void load_bank1_firmware_metadata()
+{
+    // Load firmware data from bank1 firmware's HDMI-CEC field in vector table.
+    bank1_firmware_metadata = *(Bank1FirmwareMetadata*)(0x08001B8);
+}
+
+static uint32_t get_extflash_base()
+{
+    load_bank1_firmware_metadata();
+    return align_to_next_block(((uint32_t)&__EXTFLASH_BASE__) + (bank1_firmware_metadata.external_flash_size << 12));
+}
+
 static void load_metadata()
 {
+    if (metadata == NULL)
+    {
+        metadata = ram_calloc(1, sizeof(Metadata));
+    }
+
+    uint32_t base = get_extflash_base();
+
     FILE *file = fopen(METADATA_FILE, "rb");
     if (!file)
     {
-        metadata->flash_write_pointer = (uint32_t)&__EXTFLASH_BASE__;
+        // File does not exist; invalidate_cache
+        metadata->flash_write_base = base;
+        metadata->flash_write_pointer = metadata->flash_write_base;
         return;
     }
+    fseek(file, 0, SEEK_END);
+    if(ftell(file) != sizeof(Metadata)){
+        // Stored metadata doesn't match our current structure; invalidate cache.
+        metadata->flash_write_base = base;
+        metadata->flash_write_pointer = metadata->flash_write_base;
+        return;
+    }
+    fseek(file, 0, SEEK_SET);
     fread(metadata, sizeof(Metadata), 1, file);
+    if(metadata->flash_write_base != base){
+        // The stored base address does not match whats currently in bank 1; invalidate cache.
+        metadata->flash_write_base = base;
+        metadata->flash_write_pointer = metadata->flash_write_base;
+        return;
+    } 
     fclose(file);
 }
 
@@ -141,22 +189,23 @@ static bool circular_flash_write(const char *file_path,
         *data_size = ftell(file);
         fseek(file, 0, SEEK_SET);
     }
+    uint32_t flash_write_base = get_extflash_base();
 
     // If there is not enough space available, write the file at the beginning of the flash
-    if (flash_write_pointer - (uint32_t)&__EXTFLASH_START__ + *data_size > OSPI_GetFlashSize())
+    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize())
     {
-        flash_write_pointer = align_to_next_block((uint32_t)&__EXTFLASH_BASE__);
+        flash_write_pointer = flash_write_base;
     }
 
     // Data are larger than flash size ... Abort
-    if (flash_write_pointer - (uint32_t)&__EXTFLASH_START__ + *data_size > OSPI_GetFlashSize())
+    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize())
     {
         fclose(file);
         return false;
     }
 
     uint32_t old_flash_write_pointer = flash_write_pointer;
-    uint32_t address_in_flash = flash_write_pointer - (uint32_t)&__EXTFLASH_BASE__;
+    uint32_t address_in_flash = flash_write_pointer - flash_write_base;
     uint32_t block_size = OSPI_GetSmallestEraseSize();
 
     OSPI_DisableMemoryMappedMode();

--- a/Core/Src/gw_flash_alloc.c
+++ b/Core/Src/gw_flash_alloc.c
@@ -40,9 +40,10 @@ static uint32_t flash_write_pointer = 0;
 typedef struct
 {
     unsigned int external_flash_size : 24;
+    unsigned int must_be_4: 4;
     unsigned int is_mario : 1;
     unsigned int is_zelda : 1;
-    unsigned int _padding : 6;  // Padding to align to byte boundary
+    unsigned int _padding : 2;  // Padding to align to byte boundary
 } Bank1FirmwareMetadata;
 #pragma pack(pop)
 
@@ -71,7 +72,11 @@ static uint32_t align_to_next_block(uint32_t pointer)
 static void load_bank1_firmware_metadata()
 {
     // Load firmware data from bank1 firmware's HDMI-CEC field in vector table.
-    bank1_firmware_metadata = *(Bank1FirmwareMetadata*)(0x08001B8);
+    bank1_firmware_metadata = *(Bank1FirmwareMetadata*)(0x080001B8);
+    if(bank1_firmware_metadata.must_be_4 != 4){
+        // This data came from an uncontrolled source; 0 everything out.
+        bank1_firmware_metadata = (Bank1FirmwareMetadata){0};
+    }
 }
 
 static uint32_t get_extflash_base()

--- a/startup_stm32h7b0xx.s
+++ b/startup_stm32h7b0xx.s
@@ -237,7 +237,7 @@ g_pfnVectors:
   .word     SAI2_IRQHandler                   /* SAI2                         */
   .word     OCTOSPI1_IRQHandler               /* OCTOSPI1                     */
   .word     LPTIM1_IRQHandler                 /* LPTIM1                       */
-  .word     CEC_IRQHandler                    /* HDMI_CEC                     */
+  .word     0                                 /* HDMI_CEC                     */
   .word     I2C4_EV_IRQHandler                /* I2C4 Event                   */
   .word     I2C4_ER_IRQHandler                /* I2C4 Error                   */
   .word     SPDIF_RX_IRQHandler               /* SPDIF_RX                     */


### PR DESCRIPTION
Alright, dual boot works now.

## Instructions
These instructions aren't final, they'll become simplified as stuff gets merged in, binaries get prebuilt, and I add a little more automation to `gnwmanager` to fetch the prebuilt binaries.

1. Checkout/Install this branch of `gnwmanager`: https://github.com/BrianPugh/gnwmanager/pull/248
2. Flash the patched nintendo firmware. For example, the following were what I was debugging with:
   ```bash
   # For Mario:
   gnwmanager flash-patch mario internal_flash_backup_mario.bin flash_backup_mario.bin --bootloader --internal-only
   
   # For Zelda:
   gnwmanager flash-patch zelda internal_flash_backup_zelda.bin flash_backup_zelda.bin --bootloader
   ```
   Try out other flags, it should all work.
   In the (VERY near) future, the `--bootloader` flag will also automatically download/install the sd-bootloader at address `0x08032000`. Currently the flag just saves space, and tells the firmware to launch `0x08032000` when LEFT+GAME is pressed.
3. Flash the bootloader. [Download `gnw_bootloader_0x08032000.bin` from the recent github actions](https://github.com/sylverb/game-and-watch-bootloader/actions/runs/13409854585). @sylverb I'll need you to cut a new release of the bootloader so `gnwmanager` can automatically download it from the release page. Flash it:
   ```bash
   gnwmanager flash 0x08032000 gnw_bootloader_0x08032000.bin
   ```
   As mentioned in (2), this step will be unnecessary in the near future because `gnwmanager` will do it automatically.
4. Make this branch of retro-go; I just copied the command from the CI:
   ```bash
   make -j$(nproc) GNW_TARGET=zelda COVERFLOW=1 SHARED_HIBERNATE_SAVESTATE=1 DISABLE_SPLASH_SCREEN=1 INTFLASH_BANK=2 release
   ```
5. Drop the release onto your SD card, and it should all work when you press LEFT+GAME!

## Other Nice Things
* As mentioned in our DMs, this also exposes if `mario` or `zelda` firmware are running on bank1, so we could autodetect theme based on this if we want.
* When this is done, users *no longer have to compile anything* to unlock, patch, and flash dual-boot/sd-card support. retro-go is prebuilt, the patches are prebuilt, the bootloader is prebuilt. Users just have to `pipx install gnwmanager; gnwmanager install openocd`, and their environment is completely setup.