### PR TITLE
Makefile wrapper/config generator to assist with building/flashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ screenshot.png
 .idea/
 cmake-build-debug
 .gitignore.local
+choices.yaml

--- a/firmware_helper.py
+++ b/firmware_helper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from sys import argv
+import sys
 from pathlib import Path
 
 from scripts.helper.config import (
@@ -13,60 +13,58 @@ from scripts.helper.config import (
     load_config, configure_interactively, show_summary, register_args,
 )
 from scripts.helper.makefile import make_arguments
-from scripts.helper.build   import build_firmware
-from scripts.helper.flash   import flash_firmware, firmware_backups_exist
-from scripts.helper.migrate import migrate_assets
+from scripts.helper.build   import build_firmware, build_parser   as build_subparser
+from scripts.helper.flash   import flash_firmware, firmware_backups_exist, build_parser as flash_subparser
+from scripts.helper.migrate import migrate_assets, build_parser   as migrate_subparser
 from scripts.helper.utils   import console, prompt_bool
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Retro-Go firmware helper.")
-    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing.")
+SKIP_KEYS = {"command", "config_cmd", "yes", "roms", "covers",
+             "firmware_backups", "path", "pretty", "no_clean"}
 
+
+def _split_argv(argv: list[str], sep: str = "--") -> list[list[str]]:
+    """Split argv on sep into independent command chunks."""
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    for arg in argv:
+        if arg == sep:
+            if current:
+                chunks.append(current)
+            current = []
+        else:
+            current.append(arg)
+    if current:
+        chunks.append(current)
+    return chunks or [[]]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Retro-Go firmware helper.")
     subparsers = parser.add_subparsers(dest="command")
 
-    # config
     config_parser = subparsers.add_parser("config", help="Configure build options.")
     register_args(config_parser, "core")
     config_subparsers = config_parser.add_subparsers(dest="config_cmd")
     register_args(config_subparsers.add_parser("makefile", help="Advanced Makefile settings."), "makefile")
 
-    # migrate
-    migrate_parser = subparsers.add_parser("migrate", help="Migrate assets from a legacy repository.")
-    migrate_parser.add_argument("--roms",             action="store_true", help="Migrate ROMs.")
-    migrate_parser.add_argument("--covers",           action="store_true", help="Migrate covers.")
-    migrate_parser.add_argument("--firmware-backups", action="store_true", help="Migrate firmware backups.")
-    migrate_parser.add_argument("--path",             type=str,            help="Path to old repository.")
+    migrate_subparser(subparsers)
+    build_subparser(subparsers)
+    flash_subparser(subparsers)
+    return parser
 
-    # build
-    build_parser = subparsers.add_parser("build", help="Build the firmware.")
-    build_parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts.")
 
-    # flash
-    flash_parser = subparsers.add_parser("flash", help="Flash the firmware.")
-    flash_parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts.")
-    # Add the --pretty flag here
-    flash_parser.add_argument("--pretty", action="store_true", help="Format printed commands for readability.")
-
-    args    = parser.parse_args()
-    dry_run = args.dry_run or os.environ.get("DRY_RUN", "0") == "1"
-    # Capture pretty mode from args
+def _dispatch(args: argparse.Namespace, config: BuildConfig, dry_run: bool) -> None:
+    yes_mode    = getattr(args, "yes", False)
     pretty_mode = getattr(args, "pretty", False)
 
-    # Added "pretty" to skip_keys so it doesn't pollute the BuildConfig object unless intended
-    skip_keys = {"command", "config_cmd", "dry_run", "yes", "roms", "covers", "firmware_backups", "path", "pretty"}
-    cli_args  = {k: v for k, v in vars(args).items() if v is not None and k not in skip_keys}
-    config    = load_config(cli_args)
-
-    yes_mode = getattr(args, "yes", False)
     if yes_mode and config.dual_boot:
         if not firmware_backups_exist(Path(config.backup_dir), config.target, config.offset_bytes):
             console.print("[yellow]Stock firmware backup missing in yes mode — disabling dual-boot.[/yellow]")
             config.dual_boot = False
 
-    # ── Subcommand dispatch ────────────────────────────────────────────────────
-
     if args.command == "config":
+        cli_args = {k: v for k, v in vars(args).items() if v is not None and k not in SKIP_KEYS}
         if not cli_args and not args.config_cmd:
             config = configure_interactively(config)
         config.save()
@@ -92,11 +90,22 @@ def main() -> None:
             show_summary(config, make_arguments(config))
             if not prompt_bool("Proceed with flash?"):
                 return
-        # Pass the pretty flag here
         flash_firmware(config, dry_run, pretty=pretty_mode)
 
-    else:
-        # ── Default workflow (no subcommand) ──────────────────────────────────
+
+def main() -> None:
+    # Extract global flags before splitting on '--'
+    global_parser = argparse.ArgumentParser(add_help=False)
+    global_parser.add_argument("--dry-run", action="store_true")
+    global_args, remaining = global_parser.parse_known_args(sys.argv[1:])
+    dry_run = global_args.dry_run or os.environ.get("DRY_RUN", "0") == "1"
+
+    chunks = _split_argv(remaining)
+
+    # Default workflow: no subcommand given
+    if chunks == [[]]:
+        parser = _build_parser()
+        config = load_config({})
         if not CHOICES_FILE.exists():
             console.print("[cyan]First run — starting configuration.[/cyan]")
             config = configure_interactively(config)
@@ -109,12 +118,19 @@ def main() -> None:
             parser.print_usage()
             print()
             show_summary(config, make_arguments(config))
+        return
+
+    parser = _build_parser()
+    for chunk in chunks:
+        args     = parser.parse_args(chunk)
+        cli_args = {k: v for k, v in vars(args).items() if v is not None and k not in SKIP_KEYS}
+        config   = load_config(cli_args)
+        _dispatch(args, config, dry_run)
+
 
 if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
         console.print("\n[yellow]Execution interrupted...[/yellow]")
-        # Standard exit code for SIGINT is 128 + 2 = 130
         raise SystemExit(130)
-

--- a/firmware_helper.py
+++ b/firmware_helper.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Retro-Go firmware helper — orchestrates config, build, flash, and migration."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from sys import argv
+from pathlib import Path
+
+from scripts.helper.config import (
+    BuildConfig, CHOICES_FILE,
+    load_config, configure_interactively, show_summary, register_args,
+)
+from scripts.helper.makefile import make_arguments
+from scripts.helper.build   import build_firmware
+from scripts.helper.flash   import flash_firmware, firmware_backups_exist
+from scripts.helper.migrate import migrate_assets
+from scripts.helper.utils   import console, prompt_bool
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Retro-Go firmware helper.")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing.")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # config
+    config_parser = subparsers.add_parser("config", help="Configure build options.")
+    register_args(config_parser, "core")
+    config_subparsers = config_parser.add_subparsers(dest="config_cmd")
+    register_args(config_subparsers.add_parser("makefile", help="Advanced Makefile settings."), "makefile")
+
+    # migrate
+    migrate_parser = subparsers.add_parser("migrate", help="Migrate assets from a legacy repository.")
+    migrate_parser.add_argument("--roms",             action="store_true", help="Migrate ROMs.")
+    migrate_parser.add_argument("--covers",           action="store_true", help="Migrate covers.")
+    migrate_parser.add_argument("--firmware-backups", action="store_true", help="Migrate firmware backups.")
+    migrate_parser.add_argument("--path",             type=str,            help="Path to old repository.")
+
+    # build
+    build_parser = subparsers.add_parser("build", help="Build the firmware.")
+    build_parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts.")
+
+    # flash
+    flash_parser = subparsers.add_parser("flash", help="Flash the firmware.")
+    flash_parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts.")
+    # Add the --pretty flag here
+    flash_parser.add_argument("--pretty", action="store_true", help="Format printed commands for readability.")
+
+    args    = parser.parse_args()
+    dry_run = args.dry_run or os.environ.get("DRY_RUN", "0") == "1"
+    # Capture pretty mode from args
+    pretty_mode = getattr(args, "pretty", False)
+
+    # Added "pretty" to skip_keys so it doesn't pollute the BuildConfig object unless intended
+    skip_keys = {"command", "config_cmd", "dry_run", "yes", "roms", "covers", "firmware_backups", "path", "pretty"}
+    cli_args  = {k: v for k, v in vars(args).items() if v is not None and k not in skip_keys}
+    config    = load_config(cli_args)
+
+    yes_mode = getattr(args, "yes", False)
+    if yes_mode and config.dual_boot:
+        if not firmware_backups_exist(Path(config.backup_dir), config.target, config.offset_bytes):
+            console.print("[yellow]Stock firmware backup missing in yes mode — disabling dual-boot.[/yellow]")
+            config.dual_boot = False
+
+    # ── Subcommand dispatch ────────────────────────────────────────────────────
+
+    if args.command == "config":
+        if not cli_args and not args.config_cmd:
+            config = configure_interactively(config)
+        config.save()
+
+    elif args.command == "migrate":
+        migrate_assets(
+            do_roms=args.roms,
+            do_covers=args.covers,
+            do_backups=args.firmware_backups,
+            repo_path=Path(args.path) if args.path else None,
+            yes=yes_mode,
+        )
+
+    elif args.command == "build":
+        if not yes_mode:
+            show_summary(config, make_arguments(config))
+            if not prompt_bool("Proceed with build?"):
+                return
+        build_firmware(config, dry_run)
+
+    elif args.command == "flash":
+        if not yes_mode:
+            show_summary(config, make_arguments(config))
+            if not prompt_bool("Proceed with flash?"):
+                return
+        # Pass the pretty flag here
+        flash_firmware(config, dry_run, pretty=pretty_mode)
+
+    else:
+        # ── Default workflow (no subcommand) ──────────────────────────────────
+        if not CHOICES_FILE.exists():
+            console.print("[cyan]First run — starting configuration.[/cyan]")
+            config = configure_interactively(config)
+            config.save()
+            legacy_repo = Path("..").joinpath("game-and-watch-retro-go")
+            if prompt_bool("Migrate assets from an old game-and-watch-retro-go repo?", legacy_repo.exists()):
+                migrate_assets(do_roms=True, do_covers=True, do_backups=True, repo_path=None, yes=False)
+            show_summary(config, make_arguments(config))
+        else:
+            parser.print_usage()
+            print()
+            show_summary(config, make_arguments(config))
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Execution interrupted...[/yellow]")
+        # Standard exit code for SIGINT is 128 + 2 = 130
+        raise SystemExit(130)
+

--- a/scripts/helper/build.py
+++ b/scripts/helper/build.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Firmware build orchestration."""
+
+from __future__ import annotations
+
+from scripts.helper.config import BuildConfig
+from scripts.helper.makefile import make_arguments, run_make_with_progress
+from scripts.helper.utils import run_command
+
+
+def cleanup(dry_run: bool = False) -> None:
+    """Run make clean"""
+    make_cmd = "make clean".split(' ')
+    run_command(make_cmd, dry_run)
+
+def build_firmware(config: BuildConfig, dry_run: bool = False) -> None:
+    """Compile the firmware, including filesystem images when not using an SD card."""
+    make_cmd       = ["make"] + make_arguments(config)
+    extra_targets  = [] if config.sd_card else ["frogfs_image", "littlefs_image"]
+    run_make_with_progress(make_cmd + extra_targets, "Compiling firmware…", dry_run)
+
+
+if __name__ == "__main__":
+    import argparse
+    from scripts.helper.config import load_config, show_summary, register_args
+    from scripts.helper.makefile import make_arguments
+    from scripts.helper.utils import prompt_bool
+
+    parser = argparse.ArgumentParser(description="Build Retro-Go firmware.")
+    parser.add_argument("-y", "--yes",    action="store_true", help="Skip confirmation prompts.")
+    parser.add_argument("--no-clean",      action="store_true", help="Do not trigger make clean.")
+    parser.add_argument("--dry-run",       action="store_true", help="Print commands without executing.")
+    register_args(parser, "core")
+    args = parser.parse_args()
+
+    skip_keys = {"yes", "dry_run"}
+    config = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
+
+    if not args.yes:
+        show_summary(config, make_arguments(config))
+        if not prompt_bool("Proceed with build?"):
+            raise SystemExit(0)
+
+    if not args.no_clean:
+        cleanup(dry_run=args.dry_run)
+    build_firmware(config, dry_run=args.dry_run)
+
+

--- a/scripts/helper/build.py
+++ b/scripts/helper/build.py
@@ -21,20 +21,30 @@ def build_firmware(config: BuildConfig, dry_run: bool = False) -> None:
 
 
 if __name__ == "__main__":
-    import argparse
-    from scripts.helper.config import load_config, show_summary, register_args
-    from scripts.helper.makefile import make_arguments
-    from scripts.helper.utils import prompt_bool
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-    parser = argparse.ArgumentParser(description="Build Retro-Go firmware.")
-    parser.add_argument("-y", "--yes",    action="store_true", help="Skip confirmation prompts.")
-    parser.add_argument("--no-clean",      action="store_true", help="Do not trigger make clean.")
-    parser.add_argument("--dry-run",       action="store_true", help="Print commands without executing.")
-    register_args(parser, "core")
-    args = parser.parse_args()
+import argparse
+from scripts.helper.config import load_config, show_summary, register_args
+from scripts.helper.makefile import make_arguments
+from scripts.helper.utils import prompt_bool
 
-    skip_keys = {"yes", "dry_run"}
-    config = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
+
+def build_parser(parent=None) -> argparse.ArgumentParser:
+    kwargs = dict(description="Build Retro-Go firmware.", help="Build the firmware.")
+    p = parent.add_parser("build", **kwargs) if parent else argparse.ArgumentParser(**kwargs)
+    p.add_argument("-y", "--yes",      action="store_true", help="Skip confirmation prompts.")
+    p.add_argument("--no-clean",       action="store_true", help="Do not trigger make clean.")
+    p.add_argument("--dry-run",        action="store_true", help="Print commands without executing.")
+    register_args(p, "core")
+    return p
+
+
+if __name__ == "__main__":
+    args      = build_parser().parse_args()
+    skip_keys = {"yes", "dry_run", "no_clean"}
+    config    = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
 
     if not args.yes:
         show_summary(config, make_arguments(config))
@@ -44,5 +54,3 @@ if __name__ == "__main__":
     if not args.no_clean:
         cleanup(dry_run=args.dry_run)
     build_firmware(config, dry_run=args.dry_run)
-
-

--- a/scripts/helper/config.py
+++ b/scripts/helper/config.py
@@ -171,37 +171,59 @@ class BuildConfig:
             console.print(f"[yellow]Could not load {CHOICES_FILE}: {e}[/yellow]")
             return None
 
-    def validate_flash_limit(self) -> int:
-        """Calculates total footprint and exits with RC 1 if it exceeds flash_mb."""
-        roms_bytes   = sum(f.stat().st_size for f in Path("roms").rglob("*") if f.is_file()) if Path("roms").exists() else 0
+    def validate_flash_limit(self, strict: bool = True) -> int:
+        """Calculates total footprint and warns or exits if it exceeds flash_mb.
+
+        ROM sizes are estimated post-compression using a conservative ratio for
+        8-bit systems (0.65). If strict=True (default), exits on overrun.
+        If strict=False, only warns — allowing the caller's confirm prompt to
+        serve as acknowledgment. Either way, exits immediately if the overrun
+        exceeds what maximum lzma compression could theoretically recover.
+        """
+        LZMA_ESTIMATE    = 0.65   # Conservative ratio for 8-bit ROMs
+        LZMA_THEORETICAL = 0.50   # Physical lower bound — tighter than this is impossible
+
+        rom_files    = [f for f in Path("roms").rglob("*") if f.is_file()] if Path("roms").exists() else []
+        roms_raw     = sum(f.stat().st_size for f in rom_files)
         covers_bytes = sum(f.stat().st_size for f in Path("covers").glob("*.img")) if Path("covers").exists() else 0
 
-        # Calculations[cite: 1]
+        ratio      = LZMA_ESTIMATE if self.compress == "lzma" else 1.0
+        roms_bytes = int(roms_raw * ratio)
+
         stock_offset = self.extflash_offset
-        retro_go_pkg = 2 * MiB               # Fixed overhead for frogfs/firmware
+        retro_go_pkg = 2 * MiB
         lfs_size     = self.fs_size_mb * MiB
-        if self.sd_card:
-            total_needed = stock_offset + retro_go_pkg
-        else:
-            total_needed = stock_offset + retro_go_pkg + roms_bytes + covers_bytes + lfs_size
+        overhead     = stock_offset + retro_go_pkg + covers_bytes + lfs_size
+        total_needed = overhead + (0 if self.sd_card else roms_bytes)
         flash_limit  = self.flash_mb * MiB
 
         if total_needed > flash_limit:
-            console.print("\n[bold red]ERROR: Configuration exceeds Flash capacity![/bold red]")
+            impossible = not self.sd_card and (overhead + int(roms_raw * LZMA_THEORETICAL)) > flash_limit
+
+            console.print(f"\n[bold red]{'ERROR' if impossible else 'WARNING'}: Configuration exceeds Flash capacity![/bold red]")
 
             error_table = Table(box=None, show_header=False)
             error_table.add_row("Stock Firmware Offset:", f"{stock_offset / MiB:>6.2f} MB")
-            error_table.add_row("Retro-Go System:",       f"{(retro_go_pkg / MiB):>6.2f} MB")
-            error_table.add_row("ROMs & Covers:",         f"{(roms_bytes + covers_bytes) / MiB:>6.2f} MB")
+            error_table.add_row("Retro-Go System:",       f"{retro_go_pkg / MiB:>6.2f} MB")
             if not self.sd_card:
-                error_table.add_row("LittleFS Partition:",    f"{self.fs_size_mb:>6.2f} MB")
+                error_table.add_row("ROMs (estimated):",  f"{roms_bytes / MiB:>6.2f} MB  [dim](raw: {roms_raw / MiB:.2f} MB)[/dim]")
+                error_table.add_row("Covers:",            f"{covers_bytes / MiB:>6.2f} MB")
+                error_table.add_row("LittleFS Partition:",f"{self.fs_size_mb:>6.2f} MB")
             error_table.add_row("-" * 30, "")
-            error_table.add_row("[bold]Total Required:[/bold]", f"[red]{total_needed / MiB:.2f} MB[/red]")
+            error_table.add_row("[bold]Total Estimated:[/bold]", f"[red]{total_needed / MiB:.2f} MB[/red]")
             error_table.add_row("[bold]Available Flash:[/bold]", f"{self.flash_mb:.2f} MB")
-
             console.print(error_table)
-            console.print(f"[yellow]Overage:[/yellow] [bold]{(total_needed - flash_limit) / MiB:.2f} MB[/bold]\n")
-            raise SystemExit(1)
+            console.print(f"[yellow]Overage:[/yellow] [bold]{(total_needed - flash_limit) / MiB:.2f} MB[/bold]")
+
+            if impossible:
+                console.print("[red]Overage cannot be recovered by compression — remove some ROMs.[/red]\n")
+                raise SystemExit(1)
+
+            if strict:
+                console.print("[yellow]ROM sizes are estimated post-compression and may differ.[/yellow]\n")
+                raise SystemExit(1)
+
+            console.print("[yellow]ROM sizes are estimated — actual result may fit. Proceed at your own risk.[/yellow]\n")
 
         return total_needed
 
@@ -291,7 +313,7 @@ def configure_interactively(config: BuildConfig) -> BuildConfig:
 
 def show_summary(config: BuildConfig, make_args: list[str] | None = None) -> None:
     """Print a human-readable table of the current build configuration."""
-    size_total = config.validate_flash_limit()
+    size_total = config.validate_flash_limit(strict=False)
     roms_bytes   = sum(f.stat().st_size for f in Path("roms").rglob("*")    if f.is_file()) if Path("roms").exists()   else 0
     covers_bytes = sum(f.stat().st_size for f in Path("covers").glob("*.img"))               if Path("covers").exists() else 0
 
@@ -305,7 +327,7 @@ def show_summary(config: BuildConfig, make_args: list[str] | None = None) -> Non
     table.add_row("Flash bank:",   config.bank)
     if not config.sd_card:
         table.add_row("LittleFS:", f"{config.fs_size_mb} MB")
-    table.add_row("ROMs:",         f"{roms_bytes // MiB} MB")
+    table.add_row("ROMs:",         f"{roms_bytes // MiB} MB  [dim](est. compressed: {int(roms_bytes * (0.65 if config.compress == 'lzma' else 1.0)) // MiB} MB)[/dim]")
     if covers_bytes:
         table.add_row("Covers:",   f"{covers_bytes // MiB} MB")
     table.add_row("Total size:", f"{size_total // MiB} MB")
@@ -331,5 +353,3 @@ def register_args(parser: argparse.ArgumentParser, group: str) -> None:
             parser.add_argument(arg_name, action=argparse.BooleanOptionalAction, help=f"Set {f.name}.")
         else:
             parser.add_argument(arg_name, type=actual_type, help=f"Set {f.name}.")
-
-

--- a/scripts/helper/config.py
+++ b/scripts/helper/config.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Build configuration: dataclass, persistence, interactive setup, and summary display."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, get_type_hints
+
+import yaml
+from rich.table import Table
+
+from scripts.helper.utils import console, abort, prompt_text, prompt_bool
+
+CHOICES_FILE = Path("choices.yaml")
+MiB          = 1024 * 1024
+OFFSET_MB    = {"mario": 1, "zelda": 4}
+OFFSET_BYTES = {k: v * MiB for k, v in OFFSET_MB.items()}
+
+
+@dataclass
+class BuildConfig:
+    # ── Core settings ──────────────────────────────────────────────────────────
+    target: str = field(
+        default="mario",
+        metadata={"group": "core", "prompt": "Target device (mario/zelda)"}
+    )
+    flash_mb: int = field(
+        default=0,
+        metadata={"group": "core", "prompt": "Flash chip size in MB (defaults to stock)"}
+    )
+    dual_boot: bool = field(
+        default=True,
+        metadata={"group": "core", "prompt": "Enable dual-boot (stock + retro-go)?"}
+    )
+    sd_card: bool = field(
+        default=False,
+        metadata={"group": "core", "prompt": "SD card installation?"}
+    )
+    flash_locally: bool = field(
+        default=False,
+        metadata={"group": "core", "prompt": "Flash the device on this machine?"}
+    )
+    backup_dir: str = field(
+        default="./",
+        metadata={"group": "core", "prompt": "Path to backup directory"}
+    )
+    fs_size_mb: int = field(
+        default=0,
+        metadata={"group": "core", "prompt": "LittleFS partition size in MB (automatic)"}
+    )
+
+    # ── Makefile options ───────────────────────────────────────────────────────
+    flash_bootloader: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Flash the bootloader?"}
+    )
+    single_font: bool = field(
+        default=True,
+        metadata={"group": "makefile", "prompt": "Add additional fonts?"}
+    )
+    ko_kr: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Add Korean fonts?"}
+    )
+    ja_jp: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Add Japanese fonts?"})
+    zh_cn: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Add Chinese (Simplified) fonts?"}
+    )
+    zh_tw: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Add Chinese (Traditional) fonts?"}
+    )
+    coverflow: bool = field(
+        default=False,
+        metadata={"group": "makefile"}
+    )
+    jpg_quality: int  = field(
+        default=85,
+        metadata={"group": "makefile"}
+    )
+    cheat_codes: bool = field(
+        default=False,
+        metadata={"group": "makefile", "prompt": "Enable cheat codes?"}
+    )
+    msx_use_bank_2: bool = field(
+        default=False,
+        metadata={"group": "makefile"}
+    )
+    enable_screenshot: bool = field(
+        default=True,
+        metadata={"group": "makefile", "prompt": "Enable screenshots?"}
+    )
+    shared_hibernate_savestate: bool = field(
+        default=True,
+        metadata={"group": "makefile"}
+    )
+    disable_splash_screen: bool = field(
+        default=True,
+        metadata={"group": "makefile"}
+    )
+    compress: str  = field(
+        default="lzma",
+        metadata={"group": "makefile"}
+    )
+    big_bank: bool = field(
+        default=True,
+        metadata={"group": "makefile"}
+    )
+    # ── Derived properties ─────────────────────────────────────────────────────
+
+    def __post_init__(self):
+        """Handle logic for non-interactive initialization (CLI/Env/YAML)."""
+        # If fs_size_mb is at its 'sentinel' default of 0, calculate it
+        if self.fs_size_mb == 0:
+            self.fs_size_mb = max(2, int(self.flash_mb * 0.1))
+
+    @property
+    def intflash_bank(self) -> int:
+        return 2 if self.dual_boot else 1
+
+    @property
+    def extflash_offset(self) -> int:
+        return OFFSET_BYTES[self.target] if self.dual_boot else 0
+
+    @property
+    def extflash_size_mb(self) -> int:
+        return (self.flash_mb - OFFSET_MB[self.target]) if self.dual_boot else self.flash_mb
+
+    @property
+    def bank(self) -> str:
+        return f"bank{self.intflash_bank}"
+
+    @property
+    def offset_bytes(self) -> int:
+        return OFFSET_BYTES[self.target]
+
+    @property
+    def fs_offset(self) -> int:
+        return self.extflash_size_mb * MiB - self.fs_size_mb * MiB
+
+    @property
+    def filesystem_flash_offset(self) -> int:
+        return self.extflash_offset + self.fs_offset
+
+    # ── Persistence ────────────────────────────────────────────────────────────
+
+    def save(self) -> None:
+        with open(CHOICES_FILE, "w") as f:
+            yaml.dump(asdict(self), f, default_flow_style=False, sort_keys=False)
+        console.print(f"[green]Configuration saved to {CHOICES_FILE}[/green]")
+
+    @classmethod
+    def from_yaml(cls) -> BuildConfig | None:
+        if not CHOICES_FILE.exists():
+            return None
+        try:
+            with open(CHOICES_FILE) as f:
+                data = yaml.safe_load(f)
+            if not data:
+                return None
+            known_fields = {f.name for f in dataclasses.fields(cls)}
+            return cls(**{k: v for k, v in data.items() if k in known_fields})
+        except (yaml.YAMLError, TypeError) as e:
+            console.print(f"[yellow]Could not load {CHOICES_FILE}: {e}[/yellow]")
+            return None
+
+    def validate_flash_limit(self) -> int:
+        """Calculates total footprint and exits with RC 1 if it exceeds flash_mb."""
+        roms_bytes   = sum(f.stat().st_size for f in Path("roms").rglob("*") if f.is_file()) if Path("roms").exists() else 0
+        covers_bytes = sum(f.stat().st_size for f in Path("covers").glob("*.img")) if Path("covers").exists() else 0
+
+        # Calculations[cite: 1]
+        stock_offset = self.extflash_offset
+        retro_go_pkg = 2 * MiB               # Fixed overhead for frogfs/firmware
+        lfs_size     = self.fs_size_mb * MiB
+        if self.sd_card:
+            total_needed = stock_offset + retro_go_pkg
+        else:
+            total_needed = stock_offset + retro_go_pkg + roms_bytes + covers_bytes + lfs_size
+        flash_limit  = self.flash_mb * MiB
+
+        if total_needed > flash_limit:
+            console.print("\n[bold red]ERROR: Configuration exceeds Flash capacity![/bold red]")
+
+            error_table = Table(box=None, show_header=False)
+            error_table.add_row("Stock Firmware Offset:", f"{stock_offset / MiB:>6.2f} MB")
+            error_table.add_row("Retro-Go System:",       f"{(retro_go_pkg / MiB):>6.2f} MB")
+            error_table.add_row("ROMs & Covers:",         f"{(roms_bytes + covers_bytes) / MiB:>6.2f} MB")
+            if not self.sd_card:
+                error_table.add_row("LittleFS Partition:",    f"{self.fs_size_mb:>6.2f} MB")
+            error_table.add_row("-" * 30, "")
+            error_table.add_row("[bold]Total Required:[/bold]", f"[red]{total_needed / MiB:.2f} MB[/red]")
+            error_table.add_row("[bold]Available Flash:[/bold]", f"{self.flash_mb:.2f} MB")
+
+            console.print(error_table)
+            console.print(f"[yellow]Overage:[/yellow] [bold]{(total_needed - flash_limit) / MiB:.2f} MB[/bold]\n")
+            raise SystemExit(1)
+
+        return total_needed
+
+
+def load_config(cli_args: dict[str, Any]) -> BuildConfig:
+    """
+    Merge configuration from three sources, in ascending order of precedence:
+      1. choices.yaml
+      2. Environment variables  (e.g. TARGET=zelda)
+      3. CLI arguments
+    """
+    merged: dict[str, Any] = {}
+
+    yaml_config = BuildConfig.from_yaml()
+    if yaml_config:
+        merged.update(asdict(yaml_config))
+
+    type_hints = get_type_hints(BuildConfig)
+    for f in dataclasses.fields(BuildConfig):
+        env_value = os.environ.get(f.name.upper())
+        if env_value is not None:
+            merged[f.name] = _cast_env_value(env_value, type_hints[f.name], f.name.upper())
+
+    known_fields = {f.name for f in dataclasses.fields(BuildConfig)}
+    for key, value in cli_args.items():
+        if value is not None and key in known_fields:
+            merged[key] = value
+
+    return BuildConfig(**merged) if merged else BuildConfig()
+
+
+def _cast_env_value(raw: str, target_type: type, var_name: str) -> Any:
+    if target_type is bool:
+        if raw.lower() in ("true", "1", "yes", "y"):  return True
+        if raw.lower() in ("false", "0", "no",  "n"): return False
+        abort(f"{var_name} must be boolean (true/false/1/0). Got: {raw!r}")
+    try:
+        return target_type(raw)
+    except ValueError:
+        abort(f"{var_name} must be {target_type.__name__}. Got: {raw!r}")
+
+
+def configure_interactively(config: BuildConfig) -> BuildConfig:
+    type_hints = get_type_hints(BuildConfig)
+
+    for f in dataclasses.fields(config):
+        prompt_str = f.metadata.get("prompt")
+        if not prompt_str:
+            continue
+
+        # Use the value already in the config object as the default[cite: 1]
+        current_val = getattr(config, f.name)
+
+        # Apply dynamic default for LittleFS only if current value is 0
+        if f.name == "fs_size_mb" and current_val == 0:
+            current_val = max(2, int(config.flash_mb * 0.1))
+
+        field_type = type_hints[f.name]
+        if field_type is bool:
+            val = prompt_bool(prompt_str, current_val)
+        else:
+            val = prompt_text(prompt_str, str(current_val))
+            if field_type is int:
+                try:
+                    val = int(val)
+                except ValueError:
+                    abort(f"Value for {f.name} must be an integer.")
+
+        if f.name == "target":
+            val = {"m": "mario", "mario": "mario", "z": "zelda", "zelda": "zelda"}.get(val.lower())
+            if not val:
+                abort("Target must be mario or zelda.")
+
+            # FIX: Only overwrite flash_mb with stock size if it is currently 0.
+            # This preserves saved values from choices.yaml.[cite: 1]
+            if config.flash_mb == 0:
+                config.flash_mb = OFFSET_MB[val]
+
+        setattr(config, f.name, val)
+
+    # Tally and validate before returning
+    print()
+    show_summary(config=config, make_args=None)
+    config.validate_flash_limit()
+    return config
+
+
+def show_summary(config: BuildConfig, make_args: list[str] | None = None) -> None:
+    """Print a human-readable table of the current build configuration."""
+    size_total = config.validate_flash_limit()
+    roms_bytes   = sum(f.stat().st_size for f in Path("roms").rglob("*")    if f.is_file()) if Path("roms").exists()   else 0
+    covers_bytes = sum(f.stat().st_size for f in Path("covers").glob("*.img"))               if Path("covers").exists() else 0
+
+    table = Table(title="Current Build Configuration", show_header=False, box=None)
+    table.add_column("", style="cyan",  justify="right")
+    table.add_column("", style="white")
+
+    table.add_row("Target:",       config.target.capitalize())
+    table.add_row("Flash:",        f"{config.flash_mb} MB ({'SD card' if config.sd_card else 'Flash only'})")
+    table.add_row("Dual-boot:",    "Yes" if config.dual_boot else "No")
+    table.add_row("Flash bank:",   config.bank)
+    if not config.sd_card:
+        table.add_row("LittleFS:", f"{config.fs_size_mb} MB")
+    table.add_row("ROMs:",         f"{roms_bytes // MiB} MB")
+    if covers_bytes:
+        table.add_row("Covers:",   f"{covers_bytes // MiB} MB")
+    table.add_row("Total size:", f"{size_total // MiB} MB")
+    table.add_row("Flash method:", "Local (gnwmanager)" if config.flash_locally else "Print commands")
+    if make_args:
+        table.add_row("Make args:", "")
+
+    console.print(table)
+    if make_args:
+        print("                "+" ".join(make_args))
+    console.print()
+
+
+def register_args(parser: argparse.ArgumentParser, group: str) -> None:
+    """Register BuildConfig fields for a given group as CLI arguments on a parser."""
+    type_hints = get_type_hints(BuildConfig)
+    for f in dataclasses.fields(BuildConfig):
+        if f.metadata.get("group") != group:
+            continue
+        arg_name    = f"--{f.name.replace('_', '-')}"
+        actual_type = type_hints[f.name]
+        if actual_type is bool:
+            parser.add_argument(arg_name, action=argparse.BooleanOptionalAction, help=f"Set {f.name}.")
+        else:
+            parser.add_argument(arg_name, type=actual_type, help=f"Set {f.name}.")
+
+

--- a/scripts/helper/flash.py
+++ b/scripts/helper/flash.py
@@ -100,20 +100,30 @@ def flash_firmware(config: BuildConfig, dry_run: bool = False, pretty: bool = Fa
 
 
 if __name__ == "__main__":
-    import argparse
-    from scripts.helper.config import load_config, show_summary, register_args
-    from scripts.helper.makefile import make_arguments
-    from scripts.helper.utils import prompt_bool
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-    parser = argparse.ArgumentParser(description="Flash Retro-Go firmware.")
-    parser.add_argument("-y", "--yes",    action="store_true", help="Skip confirmation prompts.")
-    parser.add_argument("--dry-run",       action="store_true", help="Print commands without executing.")
-    parser.add_argument("--pretty",        action="store_true", help="Format printed commands for readability.")
-    register_args(parser, "core")
-    args = parser.parse_args()
+import argparse
+from scripts.helper.config import load_config, show_summary, register_args
+from scripts.helper.makefile import make_arguments
+from scripts.helper.utils import prompt_bool
 
+
+def build_parser(parent=None) -> argparse.ArgumentParser:
+    kwargs = dict(description="Flash Retro-Go firmware.", help="Flash the firmware.")
+    p = parent.add_parser("flash", **kwargs) if parent else argparse.ArgumentParser(**kwargs)
+    p.add_argument("-y", "--yes",  action="store_true", help="Skip confirmation prompts.")
+    p.add_argument("--dry-run",    action="store_true", help="Print commands without executing.")
+    p.add_argument("--pretty",     action="store_true", help="Format printed commands for readability.")
+    register_args(p, "core")
+    return p
+
+
+if __name__ == "__main__":
+    args      = build_parser().parse_args()
     skip_keys = {"yes", "dry_run", "pretty"}
-    config = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
+    config    = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
 
     if config.dual_boot and not firmware_backups_exist(Path(config.backup_dir), config.target, config.offset_bytes):
         console.print("[yellow]Stock firmware backup missing — disabling dual-boot.[/yellow]")

--- a/scripts/helper/flash.py
+++ b/scripts/helper/flash.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Firmware flash orchestration."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from scripts.helper.config import BuildConfig
+from scripts.helper.utils import console, abort, find_backup_file, run_command
+
+# Known-good SHA-256 checksums for stock firmware blobs
+INTERNAL_SHA256 = {
+    "zelda": "ab37ba03bc33682c091b4e7caffd7d3102b83e675377e06d6d3046b9bf483bb6",
+    "mario": "b1f10bde11490dcf922524fcba1592ffbc47d2b9a95cda58358ab8934c747e5b",
+}
+EXTERNAL_SHA256 = {
+    "zelda": "cad7e32b0783250c29b4684fda0c8cd5b1a11e6c000ca8dd5633fd32ebffcaed",
+    "mario": "2cb99ef457b6495a99514f296a0ef07316e2b376c7c6c38309d4fff9e176b387",
+}
+
+
+def flash_commands(config: BuildConfig) -> list[list[str]]:
+    """Build the gnwmanager command(s) needed to flash the compiled firmware."""
+    build_dir = ""
+    if config.flash_locally:
+        build_dir = 'build/'
+    if config.sd_card:
+        return [[
+            "gnwmanager", "flash", config.bank, f"{build_dir}gw_retro_go_intflash.bin",
+            "--", "start", config.bank,
+            "--", "disable-debug",
+        ]]
+    return [[
+        "gnwmanager", "flash", config.bank, f"{build_dir}gw_retro_go_intflash.bin",
+        "--", "flash", "ext", f"{build_dir}frogfs.bin",   f"--offset={config.extflash_offset}",
+        "--", "flash", "ext", f"{build_dir}littlefs.bin", f"--offset={config.filesystem_flash_offset}",
+        "--", "start", config.bank,
+        "--", "disable-debug",
+    ]]
+
+
+def firmware_backups_exist(backup_dir: Path, target: str, offset_bytes: int) -> bool:
+    """Return True if both required stock firmware backup files are present."""
+    internal = find_backup_file(backup_dir, f"internal_flash_backup_{target}.bin", 131072)
+    external = find_backup_file(backup_dir, f"flash_backup_{target}.bin",          offset_bytes)
+    return bool(internal and external)
+
+
+def format_command(cmd: list[str]) -> str:
+    """Format a gnwmanager command with subcommands on new lines with backslashes."""
+    if "--" not in cmd:
+        return shlex.join(cmd)
+
+    parts = []
+    current = []
+    for arg in cmd:
+        if arg == "--" and current:
+            parts.append(shlex.join(current))
+            current = ["--"]
+        else:
+            current.append(arg)
+    if current:
+        parts.append(shlex.join(current))
+
+    return " \\\n    ".join(parts)
+
+
+def flash_firmware(config: BuildConfig, dry_run: bool = False, pretty: bool = False) -> None:
+    """Flash compiled firmware to the device, or print the commands if not flashing locally."""
+    if config.flash_locally:
+        backup_dir = Path(config.backup_dir).expanduser()
+    else:
+        backup_dir = ''
+    commands: list[list[str]] = []
+
+    if config.dual_boot:
+        internal = find_backup_file(backup_dir, f"internal_flash_backup_{config.target}.bin", 131072)
+        external = find_backup_file(backup_dir, f"flash_backup_{config.target}.bin",          config.offset_bytes)
+        if not internal or not external:
+            abort("Cannot flash dual-boot: stock firmware backups are missing.")
+        if config.flash_bootloader:
+            commands.append([
+                "gnwmanager", "flash-patch", config.target,
+                str(internal), str(external), "--bootloader",
+            ])
+
+    commands += flash_commands(config)
+
+    if config.flash_locally:
+        for cmd in commands:
+            run_command(cmd, dry_run)
+    else:
+        console.print("\n[bold green]# Run these commands to flash:[/bold green]")
+        for cmd in commands:
+            if pretty:
+                console.print(format_command(cmd))
+            else:
+                console.print(shlex.join(cmd))
+
+
+if __name__ == "__main__":
+    import argparse
+    from scripts.helper.config import load_config, show_summary, register_args
+    from scripts.helper.makefile import make_arguments
+    from scripts.helper.utils import prompt_bool
+
+    parser = argparse.ArgumentParser(description="Flash Retro-Go firmware.")
+    parser.add_argument("-y", "--yes",    action="store_true", help="Skip confirmation prompts.")
+    parser.add_argument("--dry-run",       action="store_true", help="Print commands without executing.")
+    parser.add_argument("--pretty",        action="store_true", help="Format printed commands for readability.")
+    register_args(parser, "core")
+    args = parser.parse_args()
+
+    skip_keys = {"yes", "dry_run", "pretty"}
+    config = load_config({k: v for k, v in vars(args).items() if v is not None and k not in skip_keys})
+
+    if config.dual_boot and not firmware_backups_exist(Path(config.backup_dir), config.target, config.offset_bytes):
+        console.print("[yellow]Stock firmware backup missing — disabling dual-boot.[/yellow]")
+        config.dual_boot = False
+
+    if not args.yes:
+        show_summary(config, make_arguments(config))
+        if not prompt_bool("Proceed with flash?"):
+            raise SystemExit(0)
+
+    flash_firmware(config, dry_run=args.dry_run, pretty=args.pretty)

--- a/scripts/helper/makefile.py
+++ b/scripts/helper/makefile.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Makefile argument generation and build progress tracking."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
+
+from scripts.helper.config import BuildConfig, MiB
+from scripts.helper.utils import console, abort
+
+_DRY_RUN_STEP_RE = re.compile(r"echo\s+\[\s*([^\]]+?)\s*\]\s+(.+)")
+_BUILD_OUTPUT_RE = re.compile(r"^\[\s*([^\]]+?)\s*\]\s+(.+)")
+
+
+def make_arguments(config: BuildConfig) -> list[str]:
+    """Translate a BuildConfig into a flat list of Make variable assignments."""
+    args = [
+        f"-j{os.cpu_count() or 1}",
+        "CHECK_DIRTY_SUBMODULE=0",
+        f"GNW_TARGET={config.target}",
+        f"INTFLASH_BANK={config.intflash_bank}",
+        f"EXTFLASH_OFFSET={config.extflash_offset}",
+        f"EXTFLASH_SIZE_MB={config.extflash_size_mb}",
+        f"SD_CARD={1 if config.sd_card else 0}",
+        f"SHARED_HIBERNATE_SAVESTATE={1 if config.shared_hibernate_savestate else 0}",
+        f"DISABLE_SPLASH_SCREEN={1 if config.disable_splash_screen else 0}",
+        f"ENABLE_SCREENSHOT={1 if config.enable_screenshot else 0}",
+    ]
+
+    if not config.sd_card and config.fs_size_mb:
+        args += [
+            f"FILESYSTEM_SIZE={config.fs_size_mb * MiB}",
+            f"FILESYSTEM_OFFSET={config.fs_offset}",
+        ]
+
+    if config.coverflow:      args += ["COVERFLOW=1", f"JPG_QUALITY={config.jpg_quality}"]
+    if config.single_font:    args += ["SINGLE_FONT=1"]
+    if config.cheat_codes:    args += ["CHEAT_CODES=1"]
+    if config.msx_use_bank_2: args += ["MSX_USE_BANK_2=1"]
+    if config.ko_kr:          args += ["KO_KR=1"]
+    if config.ja_jp:          args += ["JA_JP=1"]
+    if config.zh_cn:          args += ["ZH_CN=1"]
+    if config.zh_tw:          args += ["ZH_TW=1"]
+    if config.big_bank:       args += ["BIG_BANK=1"]
+    if config.compress:       args += [f"COMPRESS={config.compress}"]
+
+    if not config.sd_card:
+        args += ["frogfs_image", "littlefs_image"]
+
+    return args
+
+
+def count_make_steps(make_cmd: list[str]) -> int:
+    """Dry-run make to count bracketed output lines, used to size the progress bar."""
+    dry_cmd = ["make", "-n", "--no-print-directory"] + make_cmd[1:]
+    try:
+        result = subprocess.run(dry_cmd, capture_output=True, text=True)
+        count = sum(1 for line in result.stdout.splitlines() if _DRY_RUN_STEP_RE.search(line))
+        return max(count, 1)
+    except OSError:
+        return 1
+
+
+def run_make_with_progress(cmd: list[str], description: str, dry_run: bool) -> None:
+    """Run a make command and display a live progress bar driven by bracketed output lines."""
+    if dry_run:
+        console.print(f"[yellow][DRY-RUN] {shlex.join(cmd)}[/yellow]")
+        return
+
+    total = count_make_steps(cmd)
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task(f"[cyan]{description:<60}", total=total)
+
+        process = subprocess.Popen(
+            cmd + ["--no-print-directory"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env={**os.environ, "PYTHONUNBUFFERED": "1", "PYTHONUTF8": "1"},
+        )
+
+        for line in process.stdout:
+            match = _BUILD_OUTPUT_RE.match(line.strip())
+            if match:
+                label = f"[{match.group(1).strip()}] {match.group(2).strip()}"
+                progress.update(task, advance=1, description=f"[cyan]{label[:60].ljust(60)}")
+
+        process.wait()
+
+    if process.returncode != 0:
+        abort(f"Build failed (exit code {process.returncode})")
+
+
+if __name__ == "__main__":
+    import argparse
+    from scripts.config import load_config, register_args
+
+    parser = argparse.ArgumentParser(description="Show Make arguments for a given configuration.")
+    register_args(parser, "core")
+    register_args(parser, "makefile")
+    args = parser.parse_args()
+
+    config = load_config({k: v for k, v in vars(args).items() if v is not None})
+    print(" ".join(make_arguments(config)))
+
+

--- a/scripts/helper/makefile.py
+++ b/scripts/helper/makefile.py
@@ -38,18 +38,28 @@ def make_arguments(config: BuildConfig) -> list[str]:
             f"FILESYSTEM_OFFSET={config.fs_offset}",
         ]
 
-    if config.coverflow:      args += ["COVERFLOW=1", f"JPG_QUALITY={config.jpg_quality}"]
-    if config.single_font:    args += ["SINGLE_FONT=1"]
-    if config.cheat_codes:    args += ["CHEAT_CODES=1"]
-    if config.msx_use_bank_2: args += ["MSX_USE_BANK_2=1"]
-    if config.ko_kr:          args += ["KO_KR=1"]
-    if config.ja_jp:          args += ["JA_JP=1"]
-    if config.zh_cn:          args += ["ZH_CN=1"]
-    if config.zh_tw:          args += ["ZH_TW=1"]
-    if config.big_bank:       args += ["BIG_BANK=1"]
-    if config.compress:       args += [f"COMPRESS={config.compress}"]
+    _BOOL_FLAGS: list[tuple[bool, str]] = [
+        (config.coverflow,      "COVERFLOW"),
+        (config.single_font,    "SINGLE_FONT"),
+        (config.cheat_codes,    "CHEAT_CODES"),
+        (config.msx_use_bank_2, "MSX_USE_BANK_2"),
+        (config.ko_kr,          "KO_KR"),
+        (config.ja_jp,          "JA_JP"),
+        (config.zh_cn,          "ZH_CN"),
+        (config.zh_tw,          "ZH_TW"),
+        (config.big_bank,       "BIG_BANK"),
+    ]
+    args += [f"{var}=1" for active, var in _BOOL_FLAGS if active]
+
+    if config.coverflow: args += [f"JPG_QUALITY={config.jpg_quality}"]
+    if config.compress:  args += [f"COMPRESS={config.compress}"]
 
     if not config.sd_card:
+        if config.fs_size_mb:
+            args += [
+                f"FILESYSTEM_SIZE={config.fs_size_mb * MiB}",
+                f"FILESYSTEM_OFFSET={config.fs_offset}",
+            ]
         args += ["frogfs_image", "littlefs_image"]
 
     return args
@@ -108,7 +118,7 @@ def run_make_with_progress(cmd: list[str], description: str, dry_run: bool) -> N
 
 if __name__ == "__main__":
     import argparse
-    from scripts.config import load_config, register_args
+    from scripts.helper.config import load_config, register_args
 
     parser = argparse.ArgumentParser(description="Show Make arguments for a given configuration.")
     register_args(parser, "core")
@@ -117,5 +127,3 @@ if __name__ == "__main__":
 
     config = load_config({k: v for k, v in vars(args).items() if v is not None})
     print(" ".join(make_arguments(config)))
-
-

--- a/scripts/helper/migrate.py
+++ b/scripts/helper/migrate.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Migration helper to port assets from a legacy game-and-watch-retro-go repository."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from scripts.helper.utils import console, prompt_text
+
+
+def migrate_assets(
+    do_roms:     bool,
+    do_covers:   bool,
+    do_backups:  bool,
+    repo_path:   Path | None,
+    yes:        bool = False,
+) -> None:
+    """
+    Copy ROMs, covers, and/or firmware backups from a legacy repository.
+    If no asset flags are set, all three are migrated.
+    """
+    if not any([do_roms, do_covers, do_backups]):
+        do_roms = do_covers = do_backups = True
+
+    repo_path = _resolve_repo_path(repo_path, yes)
+    if not repo_path:
+        console.print("[yellow]Migration skipped: no valid legacy repository found.[/yellow]")
+        return
+
+    console.print(f"[cyan]Migrating from {repo_path}...[/cyan]")
+
+    if do_roms:    _migrate_roms(repo_path)
+    if do_covers:  _migrate_covers(repo_path)
+    if do_backups: _migrate_backups(repo_path)
+
+
+def _resolve_repo_path(repo_path: Path | None, yes: bool) -> Path | None:
+    if repo_path and repo_path.exists():
+        return repo_path
+
+    candidates = [d for d in Path("..").iterdir() if d.is_dir() and d.name == "game-and-watch-retro-go"]
+    if candidates:
+        console.print(f"Found legacy repository at {candidates[0]}")
+        return candidates[0]
+
+    if not yes:
+        raw = prompt_text("Old repo not found. Enter path or leave blank to skip", "")
+        if raw:
+            path = Path(raw)
+            if path.exists():
+                return path
+
+    return None
+
+
+def _migrate_roms(repo_path: Path) -> None:
+    found = False
+    source = repo_path / "roms"
+    if not source.exists():
+        return
+
+    Path("roms").mkdir(exist_ok=True)
+    iterdirs = source.iterdir()
+    if iterdirs:
+        found = True
+    for item in iterdirs:
+        destination = Path("roms") / item.name
+        shutil.copytree(item, destination, dirs_exist_ok=True) if item.is_dir() else shutil.copy2(item, destination)
+
+    # Relocate homebrew ROMs into their own subdirectory
+    Path("roms/homebrew").mkdir(exist_ok=True)
+    for rom in [Path("roms/smw/smw.sfc"), Path("roms/zelda3/zelda3.sfc")]:
+        if rom.exists():
+            rom.rename(Path("roms/homebrew") / rom.name)
+            shutil.rmtree(rom.parent)
+            console.print(f"  ✓ Migrated {rom.name} to roms/homebrew/")
+
+    if found:
+        console.print("  ✓ Migrated ROMs")
+    else:
+        console.print("  ✗ No ROMs found")
+
+
+def _migrate_covers(repo_path: Path) -> None:
+    source = repo_path / "covers"
+    if source.exists():
+        Path("covers").mkdir(exist_ok=True)
+        for cover in source.glob("*.img"):
+            shutil.copy2(cover, Path("covers") / cover.name)
+        console.print("  ✓ Migrated covers")
+    else:
+        console.print("  ✗ No covers found")
+
+
+def _migrate_backups(repo_path: Path) -> None:
+    found = False
+    backup_files = repo_path.glob("*backup*.bin")
+    if backup_files:
+        found = True
+    for backup in backup_files:
+        shutil.copy2(backup, Path("./") / backup.name)
+    if found:
+        console.print("  ✓ Migrated firmware backups")
+    else:
+        console.print("  ✓ No firmware backups found")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Migrate assets from a legacy game-and-watch-retro-go repository.")
+    parser.add_argument("--roms",             action="store_true", help="Migrate ROMs.")
+    parser.add_argument("--covers",           action="store_true", help="Migrate covers.")
+    parser.add_argument("--firmware-backups", action="store_true", help="Migrate firmware backups.")
+    parser.add_argument("--path",             type=str,            help="Path to the old repository.")
+    args = parser.parse_args()
+
+    migrate_assets(
+        do_roms=args,
+        do_covers=args.covers,
+        do_backups=args.firmware_backups,
+        repo_path=Path(args.path) if args.path else None,
+        yes=False,
+    )
+
+

--- a/scripts/helper/migrate.py
+++ b/scripts/helper/migrate.py
@@ -107,21 +107,29 @@ def _migrate_backups(repo_path: Path) -> None:
 
 
 if __name__ == "__main__":
-    import argparse
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-    parser = argparse.ArgumentParser(description="Migrate assets from a legacy game-and-watch-retro-go repository.")
-    parser.add_argument("--roms",             action="store_true", help="Migrate ROMs.")
-    parser.add_argument("--covers",           action="store_true", help="Migrate covers.")
-    parser.add_argument("--firmware-backups", action="store_true", help="Migrate firmware backups.")
-    parser.add_argument("--path",             type=str,            help="Path to the old repository.")
-    args = parser.parse_args()
+import argparse
 
+
+def build_parser(parent=None) -> argparse.ArgumentParser:
+    kwargs = dict(description="Migrate assets from a legacy game-and-watch-retro-go repository.", help="Migrate assets from a legacy repository.")
+    p = parent.add_parser("migrate", **kwargs) if parent else argparse.ArgumentParser(**kwargs)
+    p.add_argument("--roms",             action="store_true", help="Migrate ROMs.")
+    p.add_argument("--covers",           action="store_true", help="Migrate covers.")
+    p.add_argument("--firmware-backups", action="store_true", help="Migrate firmware backups.")
+    p.add_argument("--path",             type=str,            help="Path to the old repository.")
+    return p
+
+
+if __name__ == "__main__":
+    args = build_parser().parse_args()
     migrate_assets(
-        do_roms=args,
+        do_roms=args.roms,
         do_covers=args.covers,
         do_backups=args.firmware_backups,
         repo_path=Path(args.path) if args.path else None,
         yes=False,
     )
-
-

--- a/scripts/helper/utils.py
+++ b/scripts/helper/utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Shared utilities: console, prompts, file helpers, subprocess wrappers."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+
+def abort(message: str) -> None:
+    console.print(f"[bold red]{message}[/bold red]")
+    sys.exit(1)
+
+
+def prompt_text(question: str, default: str = "") -> str:
+    suffix = f" (default: {default})" if default else ""
+    return input(f"{question}{suffix}: ").strip() or default
+
+
+def prompt_bool(question: str, default: bool = True) -> bool:
+    default_str = "y" if default else "n"
+    while True:
+        raw = input(f"{question} [y/n] (default: {default_str}): ").strip().lower() or default_str
+        if raw in ("y", "yes", "1", "true"):  return True
+        if raw in ("n", "no",  "0", "false"): return False
+        console.print("[yellow]Please enter y or n.[/yellow]")
+
+
+def verify_sha256(path: Path, expected_hash: str) -> None:
+    console.print(f"  Verifying {path.name}… ", end="")
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual == expected_hash:
+        console.print("[green]OK[/green]")
+    else:
+        abort(f"Hash mismatch!\n  Expected: {expected_hash}\n  Got:      {actual}")
+
+
+def find_backup_file(base: Path, filename: str, expected_size: int) -> Path | None:
+    """Search base and its immediate subdirectories for a file matching name and size."""
+    try:
+        search_dirs = [base] + [d for d in base.iterdir() if d.is_dir()]
+    except (PermissionError, FileNotFoundError):
+        return None
+    for directory in search_dirs:
+        candidate = directory / filename
+        try:
+            if candidate.stat().st_size == expected_size:
+                return candidate
+        except FileNotFoundError:
+            pass
+    return None
+
+
+def run_command(cmd: list[str], dry_run: bool) -> None:
+    if dry_run:
+        console.print(f"[yellow][DRY-RUN] {shlex.join(cmd)}[/yellow]")
+        return
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+


### PR DESCRIPTION
This is primarily meant to help new users get aquainted with the project but it also offers a fairly straightforward method of creating a state file called choices.yaml that can persist repo/submodule updates, etc. The use cases can be fairly complex nowadays with all the different features and ways to use Retro Go, so hopefully this helps negate the need for ever more complicated logic in the Makefile. 

Current features:
- Interactive first-run configuration wizard with persistent choices.yaml state (survives repo/submodule updates)
- Config layering: choices.yaml → environment variables → CLI flags, in ascending precedence
- Build orchestration via make with a live progress bar and automatic filesystem image generation when not using SD card
- Flash command generation for gnwmanager (print-to-console or execute locally), with optional human-readable formatting (--pretty)
- Dual-boot support with stock firmware backup hash validation before flashing
- Asset migration helper to port ROMs, covers, and firmware backups from a legacy game-and-watch-retro-go repository
- Flash capacity validation: tallies ROMs, covers, and partition overhead against chip size and exits with a clear error before anything is built or flashed
- Subcommands (build, flash, config, migrate) are also runnable as standalone scripts
- Portability between Linux and Windows (Mac untested but should work too)
- No additional modules needed if gnwmanager is already installed

Planned features include:
- Validating (and potentially assisting the user in setting up) build environment (pip modules like gnwmanager, arm toolkit, etc.)
- Updating choices.yaml when new parameters get added
- making backups using gnwmanager (leaning into explicitly spelling things out for the user, not reinventing the wheel)

I expect some push-back and I welcome constructive criticism :)

Full disclosure: this is a mixture of self-written and AI tool assisted (Gemini/Claude).