### PR TITLE
Docker: refactor Dockerfile and Makefile.common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ cmake-build-debug
 .gitignore.local
 choices.yaml
 build-error.log
+.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,17 @@ FROM debian:bookworm-slim AS arm-toolchain-builder
 
 WORKDIR /opt
 
-# assume x86_64 but allow overwriting it: 
-# docker build --build-arg ARCH=$(uname -m) --tag sylverb/builder-go-sd-builder:v1.X .
-# docker build --build-arg ARCH=aarch64 --tag sylverb/builder-go-sd-builder:v1.X .
-
-ARG ARCH=x86_64
+ARG TARGETARCH
 ARG ARM_COMPILER_VERSION=15.2.rel1
-ENV ARM_COMPILER_ARCHIVE=arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi.tar.xz
 ENV ARM_COMPILER_DIR=/opt/arm-gnu-toolchain
 ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) echo "ARCH=x86_64" > /arch ;; \
+        arm64) echo "ARCH=aarch64" > /arch ;; \
+        *) echo "Unsupported TARGETARCH: $TARGETARCH"; exit 1 ;; \
+    esac;
 
 RUN apt-get update && apt-get install -y \
          curl \
@@ -22,7 +24,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt
 
-RUN curl -LO https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_COMPILER_VERSION}/binrel/${ARM_COMPILER_ARCHIVE} \
+RUN . /arch && export ARM_COMPILER_ARCHIVE="arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi.tar.xz"; \
+    curl -LO https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_COMPILER_VERSION}/binrel/${ARM_COMPILER_ARCHIVE} \
     && mkdir -p /opt \
     && tar -xf ${ARM_COMPILER_ARCHIVE} -C /opt/ \
     && mv /opt/arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi ${ARM_COMPILER_DIR} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,63 +1,123 @@
-FROM debian:bookworm-slim
+#### builder ####
+FROM debian:bookworm-slim AS arm-toolchain-builder
 
 WORKDIR /opt
 
-ENV ARM_COMPILER_VERSION=15.2.rel1
+# assume x86_64 but allow overwriting it: 
+# docker build --build-arg ARCH=$(uname -m) --tag sylverb/builder-go-sd-builder:v1.X .
+# docker build --build-arg ARCH=aarch64 --tag sylverb/builder-go-sd-builder:v1.X .
+
+ARG ARCH=x86_64
+ARG ARM_COMPILER_VERSION=15.2.rel1
+ENV ARM_COMPILER_ARCHIVE=arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi.tar.xz
+ENV ARM_COMPILER_DIR=/opt/arm-gnu-toolchain
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && apt-get install -y \
+         curl \
+         xz-utils \
+         ca-certificates \
+         binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+RUN curl -LO https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_COMPILER_VERSION}/binrel/${ARM_COMPILER_ARCHIVE} \
+    && mkdir -p /opt \
+    && tar -xf ${ARM_COMPILER_ARCHIVE} -C /opt/ \
+    && mv /opt/arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi ${ARM_COMPILER_DIR} \
+    && rm ${ARM_COMPILER_ARCHIVE}
+
+WORKDIR ${ARM_COMPILER_DIR}
+
+# Remove docs, manpages, info pages, samples, gdb extras
+RUN rm -rf \
+    share/doc \
+    share/info \
+    share/man \
+    share/gdb \
+    share/gcc-* \
+    share/gcc-arm-none-eabi \
+    include/gdb
+
+# Remove unused ARM-profile libraries
+RUN rm -rf arm-none-eabi/lib/arm
+
+# Keep ONLY: thumb/v7e-m+dp/hard (Cortex-M7 fpv5-d16 hard-float) and thumb/v6-m/nofp (Cortex-M0+ for tamp)
+RUN cd arm-none-eabi/lib/thumb \
+ && find . -mindepth 1 -maxdepth 1 \
+      ! -name v6-m \
+      ! -name v7e-m+dp \
+      -exec rm -rf {} + \
+ \
+ && find v7e-m+dp -mindepth 1 -maxdepth 1 \
+      ! -name hard \
+      -exec rm -rf {} + \
+ \
+ && find v6-m -mindepth 1 -maxdepth 1 \
+      ! -name nofp \
+      -exec rm -rf {} +
+
+# Remove unnecessary binaries, keep only commonly used embedded tools
+RUN cd bin \
+ && find . -type f \
+      ! -name 'arm-none-eabi-gcc' \
+      ! -name 'arm-none-eabi-g++' \
+      ! -name 'arm-none-eabi-as' \
+      ! -name 'arm-none-eabi-ld' \
+      ! -name 'arm-none-eabi-ar' \
+      ! -name 'arm-none-eabi-ranlib' \
+      ! -name 'arm-none-eabi-objcopy' \
+      ! -name 'arm-none-eabi-objdump' \
+      ! -name 'arm-none-eabi-size' \
+      ! -name 'arm-none-eabi-strip' \
+      ! -name 'arm-none-eabi-nm' \
+      ! -name 'arm-none-eabi-readelf' \
+      -delete
+
+# Strip binaries and libraries
+RUN find . -type f -executable \
+      -exec strip --strip-unneeded {} \; || true
+
+RUN find . -name '*.a' \
+      -exec strip -g {} \; || true
+
+
+#### runtime ####
+FROM python:3.12-slim-bookworm
+
+ENV ARM_COMPILER_DIR=/opt/arm-gnu-toolchain
+ENV GCC_PATH="${ARM_COMPILER_DIR}/bin"
+ENV PATH="${GCC_PATH}:${PATH}"
+
+COPY --from=arm-toolchain-builder \
+    ${ARM_COMPILER_DIR} \
+    ${ARM_COMPILER_DIR}
+
 RUN apt-get update -y && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         git \
-        xz-utils \
-        wget \
         make \
         patch \
-        python3 \
-        python3-pip \
-        python3-venv \
         sudo \
         xxd && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*
 
-RUN ARCH=$(uname -m) && \
-    TOOLCHAIN_FILE="arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi.tar.xz" && \
-    wget -O toolchain.md5.asc "https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_COMPILER_VERSION}/binrel/${TOOLCHAIN_FILE}.asc" && \
-    EXPECTED_MD5=$(awk '{print $1}' toolchain.md5.asc) && \
-    wget -O toolchain.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_COMPILER_VERSION}/binrel/${TOOLCHAIN_FILE}" && \
-    ACTUAL_MD5=$(md5sum toolchain.tar.xz | awk '{print $1}') && \
-    if [ "$EXPECTED_MD5" != "$ACTUAL_MD5" ]; then \
-        echo "MD5 checksum mismatch! Expected: $EXPECTED_MD5, Got: $ACTUAL_MD5" && \
-        exit 1; \
-    fi && \
-    tar xf toolchain.tar.xz && \
-    rm -f toolchain.tar.xz toolchain.md5.asc
+COPY ./requirements.txt /requirements.txt
+COPY ./external/zelda3/requirements.txt /external/zelda3/requirements.txt
 
-RUN python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install --upgrade pip && \
-    /opt/venv/bin/pip install pillow lz4 tqdm numpy gnwmanager pyyaml littlefs-python tamp
+RUN pip install --upgrade pip \
+    && pip install -r /requirements.txt \
+    && rm -rf /requirements.txt /external
 
-RUN useradd -m docker && echo "docker:docker" | chpasswd && \
-    chown docker:docker /opt && \
-    echo "docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN useradd -m \
+        -d /opt/workdir \
+        -G sudo,plugdev \
+        builder \
+    && echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-RUN echo 'export PATH="/opt/venv/bin:$PATH"' > /etc/profile.d/01-venv.sh && \
-    chmod +x /etc/profile.d/01-venv.sh
-
-RUN ARCH=$(uname -m) && \
-    echo "export GCC_PATH=/opt/arm-gnu-toolchain-${ARM_COMPILER_VERSION}-${ARCH}-arm-none-eabi/bin" \
-    > /etc/profile.d/02-gcc.sh && \
-    chmod +x /etc/profile.d/02-gcc.sh
-
-USER docker
-
-ENV PATH="/opt/venv/bin:$PATH"
-
-RUN mkdir /opt/workdir
-RUN sudo chown -R docker:docker /opt/workdir
-
+USER builder
 WORKDIR /opt/workdir
-
-CMD ["/bin/bash", "-l"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,9 @@ RUN apt-get update -y && \
         make \
         patch \
         sudo \
-        xxd && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists/*
+        xxd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /requirements.txt
 COPY ./external/zelda3/requirements.txt /external/zelda3/requirements.txt

--- a/Makefile.common
+++ b/Makefile.common
@@ -34,6 +34,12 @@ DOCKER_RUN := docker run --rm -it \
     --device=/dev/bus/usb \
     $(DOCKER_IMAGE)
 
+# Set DOCKER=1 to run build/flash/release targets inside the container rather than locally.
+# docker_build and docker_shell are always Docker-specific and unaffected by this flag.
+DOCKER ?= 0
+# Forward all user-specified variables to the inner make, minus DOCKER itself.
+_DOCKER_FWDVARS := $(filter-out DOCKER=%,$(MAKEOVERRIDES))
+
 # Docker bulid args
 ARCH ?= $(shell uname -m)
 ARM_COMPILER_VERSION ?= 15.2.rel1
@@ -680,12 +686,17 @@ LDFLAGS += $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) $(CXXLIBS) -
 LDFLAGS += -Wl,--wrap=fflush
 
 # default action: build all (FrogFS has no gw_*_extflash.bin payload — flash frogfs.bin instead)
+ifeq ($(DOCKER),1)
+all: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) -j$$(nproc) all $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 all: CheckTools CheckDirtySubmodules $(BUILD_DIR) $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET)_intflash.bin $(BUILD_DIR)/$(TARGET)_intflash2.bin
 ifneq ($(SD_CARD),0)
 all: $(BUILD_DIR)/$(TARGET)_extflash.bin
 endif
 ifeq ($(SD_CARD),0)
 all: $(FROGFS_IMAGE)
+endif
 endif
 
 #######################################
@@ -1130,11 +1141,20 @@ start:  # Start code located at INTFLASH_ADDRESS
 .PHONY: start
 
 
+ifeq ($(DOCKER),1)
+flash_intflash: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) flash_intflash $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 flash_intflash: $(BUILD_DIR)/$(TARGET)_intflash.bin
 	$(GNWMANAGER) flash $(INTFLASH_ADDRESS) $< -- start $(INTFLASH_ADDRESS)
+endif
 .PHONY: flash_intflash
 
 
+ifeq ($(DOCKER),1)
+flash_extflash: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) flash_extflash $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 flash_extflash:
 ifeq ($(SD_CARD), 0)
 	@$(MAKE) --no-print-directory $(FROGFS_IMAGE) $(LITTLEFS_IMAGE)
@@ -1142,9 +1162,14 @@ ifeq ($(SD_CARD), 0)
 		-- flash ext $(LITTLEFS_IMAGE) --offset=$(FILESYSTEM_FLASH_OFFSET) \
 		-- start $(INTFLASH_ADDRESS)
 endif
+endif
 .PHONY: flash_extflash
 
 # Programs both the external and internal flash.
+ifeq ($(DOCKER),1)
+flash: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) flash $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 flash: CheckTools CheckDirtySubmodules $(BUILD_DIR)/$(TARGET)_intflash.bin $(if $(filter-out 0,$(SD_CARD)),$(BUILD_DIR)/$(TARGET)_extflash.bin,)
 ifeq ($(SD_CARD), 0)
 	@$(MAKE) --no-print-directory $(FROGFS_IMAGE) $(LITTLEFS_IMAGE)
@@ -1157,6 +1182,7 @@ else
 	@$(GNWMANAGER) flash $(INTFLASH_ADDRESS) $(BUILD_DIR)/$(TARGET)_intflash.bin \
 		-- start $(INTFLASH_ADDRESS) \
 		$(RESET_DBGMCU_CMD)
+endif
 endif
 .PHONY: flash
 
@@ -1329,6 +1355,10 @@ $(LITTLEFS_IMAGE): create_sd_data scripts/gen_littlefs_image.py scripts/sd_cores
 littlefs_image: $(LITTLEFS_IMAGE)
 .PHONY: littlefs_image
 
+ifeq ($(DOCKER),1)
+flash_sd: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) flash_sd $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 flash_sd: CheckTools CheckDirtySubmodules $(BUILD_DIR)/$(TARGET)_intflash.bin create_sd_data
 	$(eval MAPPERS_SDPUSH := $(foreach mapper,$(MAPPER_NAMES),-- sdpush --file $(MAPPERS_DIR)/mapper_$(mapper).bin --dest-path "/cores/mappers/"))
 	@$(GNWMANAGER) flash $(INTFLASH_ADDRESS) $(BUILD_DIR)/$(TARGET)_intflash.bin \
@@ -1360,20 +1390,40 @@ flash_sd: CheckTools CheckDirtySubmodules $(BUILD_DIR)/$(TARGET)_intflash.bin cr
 		$(MAPPERS_SDPUSH) \
 		-- start $(INTFLASH_ADDRESS) \
 		$(RESET_DBGMCU_CMD)
+endif
 
 firmware_update: create_sd_folders
 	@$(MAKE) -j$(nproc) -C external/firmware_update
 	@cp external/firmware_update/build/firmware_update.bin $(RELEASE_FOLDER)/
 
-# this is creating a release folder with update archive and update application
+# Release is SD_CARD=1 only; SD_CARD=0 builds require proprietary blobs and
+# cannot produce a distributable release package.
+ifeq ($(DOCKER),1)
+release: FORCE
+ifeq ($(SD_CARD),0)
+	$(error release target requires SD_CARD=1)
+endif
+	$(V)$(DOCKER_RUN) $(MAKE) -j$$(nproc) release $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 release: CheckTools CheckDirtySubmodules $(BUILD_DIR)/$(TARGET)_intflash.bin create_sd_data firmware_update
+ifeq ($(SD_CARD),0)
+	$(error release target requires SD_CARD=1; SD_CARD=0 builds require proprietary blobs and cannot produce a distributable release)
+endif
 	@tar --format=ustar -cf $(RELEASE_FOLDER)/gw_update.tar -C sd_content $$(find sd_content -mindepth 1 -maxdepth 1 -exec basename {} \;)
 	@./scripts/gen_release_package.sh
+endif
+.PHONY: release
 
+ifeq ($(DOCKER),1)
+release_sdpush: FORCE
+	$(V)$(DOCKER_RUN) $(MAKE) release_sdpush $(_DOCKER_FWDVARS) CHECK_DIRTY_SUBMODULE=0
+else
 release_sdpush: release
 	@$(GNWMANAGER) sdpush --file $(RELEASE_FOLDER)/retro-go_update.bin --dest-path "/" \
 		-- start bank1 \
 		$(RESET_DBGMCU_CMD)
+endif
+.PHONY: release_sdpush
 
 monitor:
 	@$(GNWMANAGER) monitor --utf8
@@ -1419,10 +1469,15 @@ dump_screenshot:
 .PHONY: dump_screenshot
 
 docker_build:
-	echo $(V)docker build --network=host --build-arg ARCH=$(ARCH) -f Dockerfile --tag $(DOCKER_IMAGE) .
+	$(V)docker build --network=host --build-arg ARCH=$(ARCH) -f Dockerfile --tag $(DOCKER_IMAGE) .
 .PHONY: docker_build
 
+# DEPRECATED: use 'make release DOCKER=1' (SD_CARD=1) or 'make docker_shell' instead.
+# This target will be removed in a future release.
 docker:
+	@echo "WARNING: 'make docker' is deprecated."
+	@echo "  Use 'make release DOCKER=1' for a containerized release build (SD_CARD=1)."
+	@echo "  Use 'make docker_shell' for an interactive shell in the container."
 ifeq ($(SD_CARD),0)
 	$(V)$(DOCKER_RUN) bash
 else
@@ -1520,9 +1575,13 @@ help:
 	@echo "  SINGLE_FONT=$(SINGLE_FONT)"
 	@echo ""
 	@echo "Targets:"
-	@echo "  docker            - SD_CARD=0: interactive shell in $(DOCKER_IMAGE); SD_CARD=1: run preset release build inside container"
-	@echo "  docker_shell      - Interactive shell in $(DOCKER_IMAGE) (no preset make; same mounts as docker)"
-	@echo "  docker_build      - Builds a docker image"
+	@echo "  make [target]         - Run target locally (default: build firmware)"
+	@echo "  make [target] DOCKER=1 - Run target inside the Docker container instead."
+	@echo "                        Applies to: (default), flash, flash_intflash, flash_extflash,"
+	@echo "                        flash_sd, release, release_sdpush."
+	@echo "  docker_build          - Build the Docker container image"
+	@echo "  docker_shell          - Interactive shell in $(DOCKER_IMAGE)"
+	@echo "  docker (deprecated)   - Use 'make release DOCKER=1' or 'make docker_shell' instead"
 	@echo "  dump_screenshot   - Downloads the stored screenshot."
 	@echo "  flash             - Programs the internal and external flash"
 	@echo "  flash_all         - Alias for 'flash' (deprecated)"

--- a/Makefile.common
+++ b/Makefile.common
@@ -21,12 +21,21 @@ LARGE_FLASH ?= 0
 SD_CARD ?= 1
 
 # Docker image for reproducible ARM builds (see targets docker, docker_build).
-DOCKER_IMAGE ?= sylverb/retro-go-sd-builder:v1.4
-DOCKER_RUN := docker run --rm -it --privileged --network host \
-	--user $(shell id -u):$(shell id -g) \
-	-v $(CURDIR):/opt/workdir \
-	-v /dev/bus/usb:/dev/bus/usb \
-	$(DOCKER_IMAGE)
+RELEASE_VERSION ?= v1.4
+CONTAINER_NAME ?= retro-go-sd
+DOCKER_IMAGE ?= sylverb/retro-go-sd-builder:$(RELEASE_VERSION)
+DOCKER_RUN := docker run --rm -it \
+    --network host \
+    --name $(CONTAINER_NAME) \
+    --hostname $(CONTAINER_NAME) \
+    --user $(shell id -u):$(shell id -g) \
+    -v $(CURDIR):/opt/workdir \
+    --device=/dev/bus/usb \
+    $(DOCKER_IMAGE)
+
+# Docker bulid args
+ARCH ?= $(shell uname -m)
+ARM_COMPILER_VERSION ?= 15.2.rel1
 
 # Configure where data is stored in the external flash by
 # setting EXTFLASH_OFFSET. Useful if the first 1MB/4MB are to be preserved.
@@ -1409,20 +1418,20 @@ dump_screenshot:
 .PHONY: dump_screenshot
 
 docker_build:
-	$(V)docker build --network=host -f Dockerfile --tag $(DOCKER_IMAGE) .
+	echo $(V)docker build --network=host --build-arg ARCH=$(ARCH) -f Dockerfile --tag $(DOCKER_IMAGE) .
 .PHONY: docker_build
 
 docker:
 ifeq ($(SD_CARD),0)
-	$(V)$(DOCKER_RUN) bash -l
+	$(V)$(DOCKER_RUN) bash
 else
-	$(V)$(DOCKER_RUN) bash -l -c "make -j\$$(nproc) CHECK_DIRTY_SUBMODULE=0 COVERFLOW=1 SHARED_HIBERNATE_SAVESTATE=1 DISABLE_SPLASH_SCREEN=1 INTFLASH_BANK=2 CHEAT_CODES=1 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 release"
+	$(V)$(DOCKER_RUN) bash -c "make -j\$$(nproc) CHECK_DIRTY_SUBMODULE=0 COVERFLOW=1 SHARED_HIBERNATE_SAVESTATE=1 DISABLE_SPLASH_SCREEN=1 INTFLASH_BANK=2 CHEAT_CODES=1 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 release"
 endif
 .PHONY: docker
 
 # Interactive shell without building release (handy when SD_CARD=1 but you only want the container).
 docker_shell:
-	$(V)$(DOCKER_RUN) bash -l
+	$(V)$(DOCKER_RUN) bash
 .PHONY: docker_shell
 
 help:

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,7 @@ DOCKER_RUN := docker run --rm -it \
     --network host \
     --name $(CONTAINER_NAME) \
     --hostname $(CONTAINER_NAME) \
+    --add-host $(CONTAINER_NAME):127.0.0.1 \
     --user $(shell id -u):$(shell id -g) \
     -v $(CURDIR):/opt/workdir \
     --device=/dev/bus/usb \

--- a/Makefile.common
+++ b/Makefile.common
@@ -41,7 +41,6 @@ DOCKER ?= 0
 _DOCKER_FWDVARS := $(filter-out DOCKER=%,$(MAKEOVERRIDES))
 
 # Docker bulid args
-ARCH ?= $(shell uname -m)
 ARM_COMPILER_VERSION ?= 15.2.rel1
 
 # Configure where data is stored in the external flash by
@@ -1469,7 +1468,7 @@ dump_screenshot:
 .PHONY: dump_screenshot
 
 docker_build:
-	$(V)docker build --network=host --build-arg ARCH=$(ARCH) -f Dockerfile --tag $(DOCKER_IMAGE) .
+	$(V)docker build --network=host --build-arg ARM_COMPILER_VERSION=$(ARM_COMPILER_VERSION) -f Dockerfile --tag $(DOCKER_IMAGE) .
 .PHONY: docker_build
 
 # DEPRECATED: use 'make release DOCKER=1' (SD_CARD=1) or 'make docker_shell' instead.


### PR DESCRIPTION
Moved to builder-runtime docker image structure and added DOCKER=1 in Makefile.common so most things can easily be run in docker if so desired. 

I tested /dev/bus/usb and it works fine with --device and removing --privileged. otherwise all other changes are in the commits. I'm curious what you think so feel free to voice any opinions you have!

only undocumented change is removing venv stuff because it's unneeded in the docker environment