### PR TITLE
define `MAX_CHEAT_CODES`; default to `INTFLASH_BANK2`; add more dev instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ screenshot.png
 .idea/
 cmake-build-debug
 .gitignore.local
+*.sfc

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ DEBUG = 0
 
 OPT = -O2 -ggdb3
 
+# Default to bank 2 because sylverb's bootloader is installed at 0x08000000
+# (bank 1) on this checkout. Override on the command line for non-bootloader
+# setups, e.g. `make INTFLASH_BANK=1`.
+INTFLASH_BANK ?= 2
+
+GNWMANAGER ?= gnwmanager
+
 # To enable verbose, append VERBOSE=1 to make, e.g.:
 # make VERBOSE=1
 ifneq ($(strip $(VERBOSE)),1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -100,7 +100,7 @@ INTFLASH_BANK = 1
 endif
 endif
 
-GNWMANAGER = gnwmanager
+GNWMANAGER ?= gnwmanager
 
 # Configure external flash size in MB (Megabytes)
 EXTFLASH_SIZE_MB ?= 1
@@ -124,6 +124,9 @@ ifeq ($(CHEAT_CODES),1)
 	ifeq ($(SD_CARD),1)
 		MAX_CHEAT_CODES = 13
 	endif
+else
+	# blueMSX-go SlotManager.c (TARGET_GNW path) references MAX_CHEAT_CODES unconditionally.
+	MAX_CHEAT_CODES ?= 1
 endif
 
 # Compress supported ROMs by default. Set to 0 to disable.
@@ -1079,7 +1082,7 @@ define EXTRACT_INTERNAL_CORE_BIN_WITH_HEADER
 	rm -f "$$tmp_file"
 endef
 
-$(MAPPERS_DIR)/mapper_%.bin: $(BUILD_DIR)/$(TARGET).elf
+$(MAPPERS_DIR)/mapper_%.bin: $(BUILD_DIR)/$(TARGET).elf | create_sd_folders
 	@$(CP) -O binary --only-section=.overlay_nes_fceu_$* $< $@
 
 MAPPER_BINS := $(addprefix $(MAPPERS_DIR)/mapper_, $(addsuffix .bin, $(MAPPER_NAMES)))
@@ -1194,7 +1197,7 @@ flash_sd: CheckTools CheckDirtySubmodules $(BUILD_DIR)/$(TARGET)_intflash.bin cr
 		-- sdpush --file $(MAPPERS_DIR)/mappers_table.bin --dest-path "/cores/mappers/" \
 		-- sdpush --file $(MAPPERS_DIR)/ines_correct.bin --dest-path "/cores/mappers/" \
 		-- sdpush --file $(SD_FOLDER)/bios/nes/palettes.bin --dest-path "/bios/nes/" \
-		-- sdpush --file $(SD_FOLDER)/bios/coleco/coleco.bin --dest-path "/bios/coleco" \
+		-- sdpush --file $(SD_FOLDER)/bios/coleco/coleco.bin --dest-path "/bios/coleco/" \
 		-- sdpush --file $(SD_FOLDER)/bios/msx/msxromdb.bin --dest-path "/bios/msx/" \
 		$(MAPPERS_SDPUSH) \
 		-- start $(INTFLASH_ADDRESS) \

--- a/README.md
+++ b/README.md
@@ -590,6 +590,50 @@ If you want to have the official carts covers use the specific python toolpico8c
 
 ## Developer info
 
+### Local build, flash, and SD-card workflow
+
+For development on macOS/Linux without Docker you need `arm-none-eabi-gcc` v10+ (tested against 15.2.rel1) and the Python `requirements.txt` (`python3 -m pip install -r requirements.txt`, which installs `gnwmanager`).
+
+#### One-time per-device setup
+
+The device needs SylverB's bootloader in bank 1, with Retro-Go-SD in bank 2. Without it, the firmware-update flow that creates the SD card directory tree (`/cores`, `/bios`, `/roms/homebrew`, …) cannot run.
+
+```bash
+# Install the bootloader to bank 1 (one-time):
+gnwmanager flash-bootloader bank1
+```
+
+The `Makefile` defaults `INTFLASH_BANK=2` to match that bootloader. Pass `make INTFLASH_BANK=1` only if you installed without it.
+
+#### First-time SD-card bootstrap
+
+A freshly formatted (exFAT or FAT32) SD card lacks the directories `sdpush` needs as parents; the bootloader creates them when it unpacks `retro-go_update.bin`:
+
+```bash
+make release_sdpush GNW_TARGET=mario
+```
+
+Wait for the launcher menu to appear on the device before running any other `gnwmanager` command, or the extraction is interrupted and aborted.
+
+#### Fast-iteration workflow
+
+Once the directory tree exists, flash the firmware and regenerate the SD content locally:
+
+```bash
+make flash create_sd_data GNW_TARGET=mario
+```
+
+`create_sd_data` writes the SD files under `sd_content/`. Push only the ones you changed instead of re-sending every core, e.g.:
+
+```bash
+gnwmanager sdpush --file sd_content/cores/nes.bin --dest-path /cores/
+```
+
+#### Common gotchas
+
+- **Debug-probe `BAD_DECOMPRESS`.** Some CMSIS-DAP probes drop LZMA chunks at gnwmanager's default speed. Lower it with `make GNWMANAGER="gnwmanager --frequency 1000000"`.
+- **Stale objects after toggling a `-D` flag.** Make doesn't track `-D` changes, so toggling `CHEAT_CODES`/`COVERFLOW`/etc. between builds mixes definitions and causes link errors. Run `make clean` when you change one.
+
 ### Build and flash using Docker
 
 <details>


### PR DESCRIPTION
Previously, `CHEAT_CODES=0` wouldn't build. Additionally, most of this repo is really geared towards having this be in bank 2, so lets go ahead and make it the default.