### PR TITLE
Fix red/green swap in the Zelda launcher theme colors

### DIFF
--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -131,9 +131,11 @@ void gui_init_colors()
         gui_colors[9].bg_c = _2CC(0x100000);
         gui_colors[9].main_c = _2CC(0x900000);
         
-        // Mario/Zelda specific themes (positions 10-11)
-        gui_colors[10].main_c = _2CC(0x006000);  // Zelda green
-        gui_colors[11].main_c = _2CC(0x006000);  // Zelda green
+        // Mario/Zelda specific themes (positions 10-11).
+        // _2CC is a swizzle: feed it the red-looking literal (as entries 0-9 do)
+        // to get green out. Passing 0x006000 here yields 0x6000 (red), not green.
+        gui_colors[10].main_c = _2CC(0x600000);  // Zelda green
+        gui_colors[11].main_c = _2CC(0x600000);  // Zelda green
         
         gui_colors[23].main_c = _2CC(0x801008);  // Other theme that had _2CC
     }


### PR DESCRIPTION
gui_init_colors() builds palette entries through the _2CC macro, which swizzles its argument's byte order. Entries 0-9 already compensate by passing the red-looking literal to get the intended colour out, but the Mario/Zelda entries (positions 10-11) passed 0x006000 directly, which _2CC turns into 0x6000 (red) rather than green. Pass 0x600000 so the Zelda theme renders green as intended.