### PR TITLE
SD ROM cache: respect EXTFLASH_OFFSET as a reserved lower bound

### DIFF
--- a/Core/Inc/gw_linker.h
+++ b/Core/Inc/gw_linker.h
@@ -5,6 +5,7 @@
 extern uint8_t __EXTFLASH_START__;
 extern uint8_t __EXTFLASH_END__;
 extern uint8_t __EXTFLASH_BASE__;
+extern uint8_t __EXTFLASH_OFFSET__;  // Bytes reserved at the bottom of extflash by the chainloader (its --defsym value). Read as (uint32_t)&__EXTFLASH_OFFSET__.
 extern uint8_t __FILESYSTEM_START__;
 extern uint8_t __FILESYSTEM_END__;
 extern uint32_t __INTFLASH__;  // From linker, usually value 0x08000000 for bank 1, or 0x08100000 for bank 2

--- a/Core/Src/gw_flash_alloc.c
+++ b/Core/Src/gw_flash_alloc.c
@@ -74,9 +74,27 @@ static uint32_t align_to_next_block(uint32_t pointer)
     return (pointer + block_size - 1) & ~(block_size - 1);
 }
 
+/* Bytes to keep reserved at the bottom of external flash before the ROM cache may
+ * write. We honor the LARGER of two reservations:
+ *   1. get_ofw_extflash_size() - the active OFW's own external-flash footprint, read
+ *      from its vector-table metadata (the stock retro-go behavior); and
+ *   2. __EXTFLASH_OFFSET__ - the chainloader's reserved bottom region (its build-time
+ *      EXTFLASH_OFFSET, passed in via --defsym).
+ * The chainloader packs BOTH games' asset blocks, BOTH OFW backups, and the FAT module
+ * store into the bottom __EXTFLASH_OFFSET__ bytes; get_ofw_extflash_size() only describes
+ * the single booted game, so on its own it lets the ROM cache erase straight over the OFW
+ * backups and FAT store. Using the max keeps the cache clear of all of it, and degrades to
+ * the stock behavior when EXTFLASH_OFFSET is 0. */
+static uint32_t get_reserved_extflash_size()
+{
+    uint32_t ofw = get_ofw_extflash_size();
+    uint32_t reserved = (uint32_t)&__EXTFLASH_OFFSET__;
+    return ofw > reserved ? ofw : reserved;
+}
+
 static uint32_t get_extflash_base()
 {
-    return align_to_next_block(((uint32_t)&__EXTFLASH_BASE__) + get_ofw_extflash_size());
+    return align_to_next_block(((uint32_t)&__EXTFLASH_BASE__) + get_reserved_extflash_size());
 }
 
 static void reset_metadata(uint32_t flash_write_base) {
@@ -217,13 +235,13 @@ static bool circular_flash_write(const char *file_path,
     uint32_t flash_write_base = get_extflash_base();
 
     // If there is not enough space available, write the file at the beginning of the flash
-    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize() - get_ofw_extflash_size())
+    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize() - get_reserved_extflash_size())
     {
         flash_write_pointer = flash_write_base;
     }
 
     // Data are larger than flash size ... Abort
-    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize() - get_ofw_extflash_size())
+    if (flash_write_pointer - flash_write_base + *data_size > OSPI_GetFlashSize() - get_reserved_extflash_size())
     {
         fclose(file);
         return false;

--- a/STM32H7B0VBTx_SDCARD.ld
+++ b/STM32H7B0VBTx_SDCARD.ld
@@ -75,8 +75,9 @@ __FLASH2_LENGTH__   = 256K; /* Bank 2 */
 __RAM_FCEUMM_MAPPER_LENGTH__ = 48K; /* Current FCEUMM mapper code */
 
 /* Usefull only for round robin flash allocator */
+__EXTFLASH_OFFSET__ = DEFINED(__EXTFLASH_OFFSET__) ? __EXTFLASH_OFFSET__ : 0;  /* bytes reserved at the bottom by the chainloader */
 __EXTFLASH_BASE__ = 0x90000000;  /* Beginning of addressable extflash addresses */
-__EXTFLASH_START__ = __EXTFLASH_BASE__;  /* Beginning of where we're going to store emulator and rom data */
+__EXTFLASH_START__ = __EXTFLASH_BASE__ + __EXTFLASH_OFFSET__;  /* Beginning of where we're going to store emulator and rom data (respect the reserved offset, matching STM32H7B0VBTx_FLASH.ld) */
 
 __RAM_START__       = 0x24000000;
 __RAM_UC_START__    = __RAM_START__;


### PR DESCRIPTION
The SD-card round-robin ROM cache reserved only get_ofw_extflash_size() bytes at the bottom of external flash and wrote ROMs across everything above it, ignoring any larger region a host reserves below the cache via EXTFLASH_OFFSET. Reserve max(get_ofw_extflash_size(), EXTFLASH_OFFSET) for both the write base and the capacity bound, so the cache never writes below the configured offset. EXTFLASH_OFFSET is exposed to C via gw_linker.h, and STM32H7B0VBTx_SDCARD.ld applies it to __EXTFLASH_START__ to match STM32H7B0VBTx_FLASH.ld. Degrades to the previous behavior when EXTFLASH_OFFSET is 0.