### PR TITLE
add optional remote input for gamepad/keyboard and general input automation

### DIFF
--- a/Core/Inc/gw_buttons.h
+++ b/Core/Inc/gw_buttons.h
@@ -18,5 +18,8 @@
 
 uint32_t buttons_get();
 
+#ifdef REMOTE_INPUT
+#define SRAM_REMOTE_INPUT_ADDR 0x2001FFF4UL
+#endif
 
 #endif

--- a/Core/Src/gw_buttons.c
+++ b/Core/Src/gw_buttons.c
@@ -20,10 +20,28 @@ uint32_t buttons_get() {
     bool start = HAL_GPIO_ReadPin(BTN_START_GPIO_Port, BTN_START_Pin) == GPIO_PIN_RESET;
     bool select = HAL_GPIO_ReadPin(BTN_SELECT_GPIO_Port, BTN_SELECT_Pin) == GPIO_PIN_RESET;
 
-    return (
+    uint32_t buttons = (
         left | (up << 1) | (right << 2) | (down << 3) | (a << 4) | (b << 5) |
         (time << 6) | (game << 7) | (pause << 8) | (power << 9) | (start << 10) | (select << 11)
     );
+
+#ifdef REMOTE_INPUT
+    uint32_t remote = *(volatile uint32_t *)SRAM_REMOTE_INPUT_ADDR;
+    if (remote & (1 << 0))  buttons |= B_Up;
+    if (remote & (1 << 1))  buttons |= B_Down;
+    if (remote & (1 << 2))  buttons |= B_Left;
+    if (remote & (1 << 3))  buttons |= B_Right;
+    if (remote & (1 << 4))  buttons |= B_A;
+    if (remote & (1 << 5))  buttons |= B_B;
+    if (remote & (1 << 6))  buttons |= B_START;
+    if (remote & (1 << 7))  buttons |= B_SELECT;
+    if (remote & (1 << 8))  buttons |= B_PAUSE;
+    if (remote & (1 << 9))  buttons |= B_GAME;
+    if (remote & (1 << 10)) buttons |= B_TIME;
+    if (remote & (1 << 11)) buttons |= B_POWER;
+#endif
+
+    return buttons;
 
 
 }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -262,6 +262,10 @@ int main(void)
   uint8_t trigger_wdt_bsod = 0;
   uint8_t boot_mode = BOOT_MODE_APP;
 
+#ifdef REMOTE_INPUT
+  *(volatile uint32_t *)SRAM_REMOTE_INPUT_ADDR = 0;
+#endif
+
 #if 0
   for(int i = 0; i < 1000000; i++) {
     __NOP();

--- a/Makefile.common
+++ b/Makefile.common
@@ -638,6 +638,11 @@ ifdef MAX_CHEAT_CODES
 C_DEFS += -DMAX_CHEAT_CODES=$(MAX_CHEAT_CODES)
 endif
 
+REMOTE_INPUT ?= 0
+ifeq ($(REMOTE_INPUT), 1)
+C_DEFS += -DREMOTE_INPUT
+endif
+
 # AS includes
 AS_INCLUDES +=
 
@@ -715,6 +720,7 @@ else
 endif
 
 LDFLAGS += -Wl,--defsym=__FLASH_LENGTH__=$(FLASH_LENGTH)
+LDFLAGS += -Wl,--defsym=REMOTE_INPUT=$(REMOTE_INPUT)
 
 #######################################
 # LDFLAGS

--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -67,6 +67,7 @@ _Min_Stack_Size = 20 * 1024; /* required amount of stack */
 __NULLPTR_LENGTH__  = 0x0;
 __ITCMRAM_LENGTH__  = 64K;
 __DTCMRAM_LENGTH__  = 128K;
+__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? REMOTE_INPUT * 12 : 0;
 __RAM_UC_LENGTH__   = 300K;
 __RAM_CORE_LENGTH__ = 0K;
 __RAM_EMU_LENGTH__  = 1024K - __RAM_UC_LENGTH__ - __RAM_CORE_LENGTH__;
@@ -850,9 +851,10 @@ INCLUDE build/fceumm_mappers.ld
   /* User_heap_stack section, used to check that there is enough RAM left */
   ._user_stack :
   {
-    /* Pad the unused area between the last symbol and the start of the redzone */
+    /* Pad the unused area between the last symbol and the start of the redzone.
+       We reserve space at the top of DTCMRAM for boot magic and remote input if enabled. */
     __dtc_padding_start__ = .;
-    . = . + __DTCMRAM_LENGTH__ - (_Min_Stack_Size + _Stack_Redzone_Size) - (__dtc_padding_start__ - __dtcram_start__);
+    . = . + __DTCMRAM_LENGTH__ - __REMOTE_INPUT_RESERVE__ - (_Min_Stack_Size + _Stack_Redzone_Size) - (__dtc_padding_start__ - __dtcram_start__);
     __dtc_padding_end__ = .;
 
     _stack_redzone = .;
@@ -860,6 +862,7 @@ INCLUDE build/fceumm_mappers.ld
     _stack_bottom = .;
     . = . + _Min_Stack_Size;
     _stack_top = .;
+    . = . + __REMOTE_INPUT_RESERVE__;
     __dtcram_end__ = .;
   } >DTCMRAM
 

--- a/STM32H7B0VBTx_SDCARD.ld
+++ b/STM32H7B0VBTx_SDCARD.ld
@@ -67,6 +67,7 @@ _Min_Stack_Size = 24 * 1024; /* required amount of stack */
 __NULLPTR_LENGTH__  = 0x0;
 __ITCMRAM_LENGTH__  = 64K;
 __DTCMRAM_LENGTH__  = 128K;
+__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? REMOTE_INPUT * 12 : 0;
 __RAM_UC_LENGTH__   = 300K; /* framebuffer : 2 x 320 x 240 x 16 bits */
 __RAM_EMU_LENGTH__  = 1024K - __RAM_UC_LENGTH__;
 __AHBRAM_LENGTH__   = 128K;
@@ -851,9 +852,10 @@ INCLUDE build/fceumm_mappers.ld
   /* User_heap_stack section, used to check that there is enough RAM left */
   ._user_stack :
   {
-    /* Pad the unused area between the last symbol and the start of the redzone */
+    /* Pad the unused area between the last symbol and the start of the redzone.
+       We reserve space at the top of DTCMRAM for boot magic and remote input if enabled. */
     __dtc_padding_start__ = .;
-    . = . + __DTCMRAM_LENGTH__ - (_Min_Stack_Size + _Stack_Redzone_Size) - (__dtc_padding_start__ - __dtcram_start__);
+    . = . + __DTCMRAM_LENGTH__ - __REMOTE_INPUT_RESERVE__ - (_Min_Stack_Size + _Stack_Redzone_Size) - (__dtc_padding_start__ - __dtcram_start__);
     __dtc_padding_end__ = .;
 
     _stack_redzone = .;
@@ -861,6 +863,7 @@ INCLUDE build/fceumm_mappers.ld
     _stack_bottom = .;
     . = . + _Min_Stack_Size;
     _stack_top = .;
+    . = . + __REMOTE_INPUT_RESERVE__;
     __dtcram_end__ = .;
   } >DTCMRAM
 

--- a/scripts/harness.py
+++ b/scripts/harness.py
@@ -1,0 +1,111 @@
+"""Test-harness and debug-probe helpers for retro-go.
+
+Exposes symbol resolution, state peeking, and target loop checks.
+"""
+from __future__ import annotations
+
+import signal
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+# Sane default pointer for resolving symbols
+DEFAULT_ELF = Path(__file__).resolve().parents[1] / "build" / "gw_retro_go.elf"
+
+
+@contextmanager
+def time_budget(seconds: float, label: str):
+    """Hard wall-clock bound using SIGALRM to prevent hanging on a wedged probe."""
+    def _fire(signum, frame):
+        raise TimeoutError(f"{label}: exceeded {seconds:.0f}s budget (probe wedged?)")
+    old = signal.signal(signal.SIGALRM, _fire)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old)
+
+
+def resolve_symbol(name: str, elf: Path | str = DEFAULT_ELF) -> int:
+    """Return the load address of a symbol from the ELF symbol table via arm-none-eabi-nm.
+    
+    Supports LTO name-mangling by matching symbol names starting with the prefix.
+    """
+    elf_path = Path(elf)
+    if not elf_path.exists():
+        raise FileNotFoundError(f"ELF file not found at {elf_path}")
+    
+    out = subprocess.run(
+        ["arm-none-eabi-nm", str(elf_path)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        addr, _kind, sym = parts
+        if sym == name or sym.startswith(name + "."):
+            return int(addr, 16)
+    raise KeyError(f"symbol {name!r} not found in {elf_path}")
+
+
+def read_u32_symbol(backend, name: str, offset: int = 0, elf: Path | str = DEFAULT_ELF) -> int:
+    """Read a uint32 at the resolved symbol (+offset)."""
+    return backend.read_uint32(resolve_symbol(name, elf) + offset)
+
+
+def retrogo_running(backend, settle: float = 0.25, min_ticks: int = 10,
+                    max_ticks: int = 100000, budget: float = 15.0, elf: Path | str = DEFAULT_ELF) -> tuple[bool, str]:
+    """Return (ok, detail): is the retro-go firmware main loop running?
+    
+    Validates execution by asserting that the uwTick counter is incrementing.
+    """
+    try:
+        with time_budget(budget, "retrogo_running"):
+            addr = resolve_symbol("uwTick", elf)
+            backend.halt()
+            t0 = backend.read_uint32(addr)
+            backend.resume()
+            time.sleep(settle)
+            backend.halt()
+            t1 = backend.read_uint32(addr)
+            backend.resume()
+    except Exception as e:
+        return False, str(e)
+    
+    delta = (t1 - t0) & 0xFFFFFFFF
+    ok = min_ticks <= delta <= max_ticks
+    return ok, f"uwTick {t0}->{t1} (+{delta} in {settle:.2f}s)"
+
+
+def safe_read_u32(backend, addr: int) -> int | None:
+    """Read a uint32, returning None instead of raising if the read fails."""
+    try:
+        return backend.read_uint32(addr)
+    except Exception:
+        return None
+
+
+def wait_u32(dev, addr: int, test_fn, timeout: float = 90.0,
+             interval: float = 2.0, reconnect: bool = True) -> int | None:
+    """Poll an address until test_fn(value) is true or timeout elapses."""
+    deadline = time.time() + timeout
+    while True:
+        if reconnect:
+            try:
+                dev.reconnect()
+            except Exception:
+                pass
+        last = safe_read_u32(dev.backend, addr)
+        if last is not None:
+            try:
+                if test_fn(last):
+                    return last
+            except Exception:
+                pass
+        if time.time() >= deadline:
+            return last
+        time.sleep(interval)

--- a/scripts/remote_control.py
+++ b/scripts/remote_control.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Manually drive the Game & Watch UI over the debug probe — keyboard or gamepad.
+
+Thin front-end over the shared backend in `scripts/common/remote_input.py`. The
+device mechanism lives there; this file is input capture + a key map, exposed as
+pollable InputSource objects so the fastcap capture tool can drive the device
+live while it records.
+
+REQUIRES a firmware built with the remote-input hook compiled in (default on;
+opt out with `make REMOTE_INPUT=0`). A build without the hook does nothing.
+
+Modes
+-----
+  auto (default)  try a gamepad first (Linux evdev / Pygame); fall back to the keyboard if
+                  none is found.
+  --gamepad       force a controller via evdev/pygame. OS key-up events give TRUE
+                  press/release — let go and it releases instantly.
+  --keyboard      force raw-terminal keypresses. Terminals send key-down but no
+                  key-up, so a held key stays down for --hold ms and releases when
+                  the terminal's auto-repeat stops (release lags by ~--hold ms).
+
+`WindowKeySource` here is the same idea for the fastcap OpenCV live window
+(`fastcap.py capture --live`): watch the stream and drive in one window.
+
+Keyboard map
+------------
+    arrows = D-pad      a/Enter = A      b/Backspace = B
+    s = Start           Tab = Select     p = Pause
+    g = Game            t = Time         P (shift) = Power
+    q / Ctrl-C = quit (clears the shadow cell on the way out)
+
+The Left+Game combo is the launcher-escape macro (works in the menu and inside a
+running stock game). Hold Left, tap Game — or just press both.
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import os
+import select
+import sys
+import time
+from pathlib import Path
+
+# Platform flags
+IS_WINDOWS = sys.platform == "win32"
+
+if not IS_WINDOWS:
+    import termios
+    import tty
+
+# Add the scripts directory to sys.path so we can import remote_input.py locally
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import remote_input as ri
+
+# Single-byte / control keys -> button bit.
+KEYMAP = {
+    "\r": ri.BTN_A, "\n": ri.BTN_A, "a": ri.BTN_A,
+    "\x7f": ri.BTN_B, "\b": ri.BTN_B, "b": ri.BTN_B,
+    "s": ri.BTN_START, "\t": ri.BTN_SELECT,
+    "p": ri.BTN_PAUSE, "g": ri.BTN_GAME, "t": ri.BTN_TIME,
+    "P": ri.BTN_PWR,
+}
+ARROWS = {
+    "\x1b[A": ri.BTN_UP, "\x1b[B": ri.BTN_DOWN,
+    "\x1b[C": ri.BTN_RIGHT, "\x1b[D": ri.BTN_LEFT,
+}
+
+
+def _parse_keys(buf: str):
+    """Yield button bits from a raw stdin chunk; None signals quit."""
+    i = 0
+    while i < len(buf):
+        if buf[i] == "\x1b":
+            seq = buf[i:i + 3]
+            if seq in ARROWS:
+                yield ARROWS[seq]
+                i += 3
+                continue
+            yield None  # lone ESC = quit
+            return
+        ch = buf[i]
+        if ch in ("q", "\x03"):
+            yield None
+            return
+        if ch in KEYMAP:
+            yield KEYMAP[ch]
+        i += 1
+
+
+# ---- Pollable input sources ----------------------------------------------
+
+class InputSource:
+    def open(self) -> "InputSource":
+        return self
+
+    def close(self) -> None:
+        pass
+
+    def poll(self, now: float):  # -> int mask | None
+        raise NotImplementedError
+
+
+class KeyboardSource(InputSource):
+    """Raw-terminal keypresses with a hold timer (cross-platform compatible)."""
+
+    def __init__(self, hold_ms: int = 150):
+        self.hold_s = hold_ms / 1000.0
+        self._expiry: dict[int, float] = {}
+        self._fd = None
+        self._old = None
+
+    def open(self) -> "KeyboardSource":
+        if not IS_WINDOWS:
+            self._fd = sys.stdin.fileno()
+            self._old = termios.tcgetattr(self._fd)
+            atexit.register(self._restore)
+            tty.setraw(self._fd)
+        return self
+
+    def _restore(self) -> None:
+        if not IS_WINDOWS and self._old is not None and self._fd is not None:
+            try:
+                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old)
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        self._restore()
+
+    def poll(self, now: float):
+        if IS_WINDOWS:
+            import msvcrt
+            while msvcrt.kbhit():
+                ch = msvcrt.getch()
+                # Intercept Windows extended scan codes (Arrows)
+                if ch in (b"\x00", b"\xe0"):
+                    ch2 = msvcrt.getch()
+                    win_arrows = {b"H": ri.BTN_UP, b"P": ri.BTN_DOWN, b"M": ri.BTN_RIGHT, b"K": ri.BTN_LEFT}
+                    if ch2 in win_arrows:
+                        self._expiry[win_arrows[ch2]] = now + self.hold_s
+                else:
+                    try:
+                        decoded = ch.decode("utf-8", errors="ignore")
+                        if decoded in ("q", "\x03"):
+                            return None
+                        if decoded in KEYMAP:
+                            self._expiry[KEYMAP[decoded]] = now + self.hold_s
+                    except Exception:
+                        pass
+        else:
+            r, _, _ = select.select([self._fd], [], [], 0)
+            if r:
+                try:
+                    raw_bytes = os.read(self._fd, 64)
+                    buf = raw_bytes.decode("utf-8", errors="ignore")
+
+                    for bit in _parse_keys(buf):
+                        if bit is None:
+                            return None
+                        self._expiry[bit] = now + self.hold_s
+                except OSError:
+                    pass
+
+        self._expiry = {b: t for b, t in self._expiry.items() if t > now}
+        mask = 0
+        for b in self._expiry:
+            mask |= 1 << b
+        return mask
+
+
+# ---- Gamepad Backends -----------------------------------------------------
+
+class EvdevGamepadBackend:
+    """Linux-native evdev backend mapping raw kernel event character devices."""
+    def __init__(self, path: str | None = None):
+        self.path = path
+        self._pad = None
+        self._held = 0
+        self._keymap = None
+        self._ecodes = None
+
+    def open(self):
+        from evdev import InputDevice, ecodes, list_devices
+        self._ecodes = ecodes
+
+        if self.path:
+            self._pad = InputDevice(self.path)
+        else:
+            for dp in list_devices():
+                d = InputDevice(dp)
+                caps = d.capabilities().get(ecodes.EV_KEY, [])
+                if ecodes.BTN_SOUTH in caps or ecodes.BTN_GAMEPAD in caps:
+                    self._pad = d
+                    break
+            if not self._pad:
+                raise RuntimeError("No evdev gamepad found")
+
+        self._keymap = {
+            ecodes.BTN_SOUTH: ri.BTN_A, ecodes.BTN_EAST: ri.BTN_B,
+            ecodes.BTN_START: ri.BTN_START, ecodes.BTN_SELECT: ri.BTN_SELECT,
+            ecodes.BTN_TR: ri.BTN_GAME, ecodes.BTN_TL: ri.BTN_TIME,
+            ecodes.BTN_THUMBL: ri.BTN_PAUSE, ecodes.BTN_MODE: ri.BTN_PWR,
+        }
+        return self
+
+    @property
+    def name(self) -> str:
+        return f"{self._pad.name} ({self._pad.path})"
+
+    def close(self) -> None:
+        if self._pad is not None:
+            try:
+                self._pad.close()
+            except Exception:
+                pass
+
+    def _apply(self, ev) -> None:
+        ec = self._ecodes
+        if ev.type == ec.EV_KEY and ev.code in self._keymap:
+            bit = 1 << self._keymap[ev.code]
+            if ev.value:
+                self._held |= bit
+            else:
+                self._held &= ~bit
+        elif ev.type == ec.EV_ABS:
+            if ev.code == ec.ABS_HAT0X:
+                self._held &= ~((1 << ri.BTN_LEFT) | (1 << ri.BTN_RIGHT))
+                if ev.value < 0:
+                    self._held |= 1 << ri.BTN_LEFT
+                elif ev.value > 0:
+                    self._held |= 1 << ri.BTN_RIGHT
+            elif ev.code == ec.ABS_HAT0Y:
+                self._held &= ~((1 << ri.BTN_UP) | (1 << ri.BTN_DOWN))
+                if ev.value < 0:
+                    self._held |= 1 << ri.BTN_UP
+                elif ev.value > 0:
+                    self._held |= 1 << ri.BTN_DOWN
+
+    def poll(self, now: float) -> int:
+        while True:
+            try:
+                ev = self._pad.read_one()
+            except (BlockingIOError, OSError):
+                break
+            if ev is None:
+                break
+            self._apply(ev)
+        return self._held
+
+
+class PygameGamepadBackend:
+    """Cross-platform SDL backend for macOS, Windows, and local Linux hosts."""
+    def __init__(self, path: str | None = None):
+        self.index = int(path) if (path and path.isdigit()) else 0
+        self._joystick = None
+        self._held = 0
+
+    def open(self):
+        # Prevent Pygame from initializing an unnecessary GUI window context
+        if "SDL_VIDEODRIVER" not in os.environ:
+            os.environ["SDL_VIDEODRIVER"] = "dummy"
+
+        import pygame
+        pygame.init()
+        pygame.joystick.init()
+
+        if pygame.joystick.get_count() == 0:
+            raise RuntimeError("No gamepads found via SDL backend")
+
+        self._joystick = pygame.joystick.Joystick(self.index)
+        self._joystick.init()
+        return self
+
+    @property
+    def name(self) -> str:
+        return f"{self._joystick.get_name()} (SDL Index {self.index})"
+
+    def close(self) -> None:
+        import pygame
+        if self._joystick:
+            self._joystick.quit()
+        pygame.joystick.quit()
+
+    def poll(self, now: float) -> int:
+        import pygame
+        pygame.event.pump()
+
+        self._held = 0
+        num_buttons = self._joystick.get_numbuttons()
+
+        # Dynamic mapping layout capturing standard SDL mapping profiles (Xbox, DualShock, Switch)
+        button_map = {
+            0: ri.BTN_A,       # South
+            1: ri.BTN_B,       # East
+            4: ri.BTN_SELECT,  # Back / Share / Select
+            6: ri.BTN_SELECT,
+            7: ri.BTN_START,   # Start Options
+            11: ri.BTN_START,
+            9: ri.BTN_TIME,    # Left Bumper / Shoulder
+            10: ri.BTN_GAME,   # Right Bumper / Shoulder
+            8: ri.BTN_PAUSE,   # Guide / Home system fallbacks
+            12: ri.BTN_PWR,
+        }
+
+        for btn_idx, btn_bit in button_map.items():
+            if btn_idx < num_buttons and self._joystick.get_button(btn_idx):
+                self._held |= (1 << btn_bit)
+
+        # Evaluate the directional Hat (D-Pad)
+        if self._joystick.get_numhats() > 0:
+            hat_x, hat_y = self._joystick.get_hat(0)
+            if hat_x < 0:  self._held |= (1 << ri.BTN_LEFT)
+            elif hat_x > 0: self._held |= (1 << ri.BTN_RIGHT)
+            if hat_y > 0:  self._held |= (1 << ri.BTN_UP)    # SDL Up axis maps positively
+            elif hat_y < 0: self._held |= (1 << ri.BTN_DOWN)
+
+        return self._held
+
+
+class GamepadSource(InputSource):
+    """Proxy abstraction layer routing to evdev on Linux or pygame on macOS/Windows."""
+
+    def __init__(self, path: str | None = None):
+        self.path = path
+        self._backend = None
+
+    def open(self) -> "GamepadSource":
+        if sys.platform == "linux":
+            try:
+                self._backend = EvdevGamepadBackend(self.path).open()
+                return self
+            except Exception:
+                pass  # Fall back to pygame if evdev fails inside the platform environment
+
+        self._backend = PygameGamepadBackend(self.path).open()
+        return self
+
+    @property
+    def name(self) -> str:
+        return self._backend.name if self._backend else "?"
+
+    def close(self) -> None:
+        if self._backend:
+            self._backend.close()
+
+    def poll(self, now: float):
+        return self._backend.poll(now) if self._backend else 0
+
+
+class WindowKeySource(InputSource):
+    """Keyboard control fed from an OpenCV window's waitKeyEx()."""
+
+    DPAD = {
+        ord("w"): ri.BTN_UP,   ord("a"): ri.BTN_LEFT,
+        ord("s"): ri.BTN_DOWN, ord("d"): ri.BTN_RIGHT,
+        65362: ri.BTN_UP, 65364: ri.BTN_DOWN,
+        65361: ri.BTN_LEFT, 65363: ri.BTN_RIGHT,
+    }
+    BTNS = {
+        ord("j"): ri.BTN_A,     13: ri.BTN_A,
+        ord("k"): ri.BTN_B,      8: ri.BTN_B,
+        ord("u"): ri.BTN_START, ord("i"): ri.BTN_SELECT,
+        ord("g"): ri.BTN_GAME,  ord("t"): ri.BTN_TIME,
+        ord("p"): ri.BTN_PAUSE, ord("o"): ri.BTN_PWR,
+    }
+    QUIT = {ord("q"), 27}
+    KEY_HELP = ("WASD/arrows=D-pad  J/Enter=A  K/Bksp=B  U=Start  I=Select  "
+                "G=Game  T=Time  P=Pause  O=Power  |  F=FPS  Q/Esc=quit")
+
+    def __init__(self, hold_ms: int = 150):
+        self.hold_s = hold_ms / 1000.0
+        self._expiry: dict[int, float] = {}
+        self.quit = False
+
+    def feed(self, key: int, now: float) -> None:
+        if key < 0:
+            return
+        if key in self.QUIT:
+            self.quit = True
+        elif key in self.DPAD:
+            self._expiry[self.DPAD[key]] = now + self.hold_s
+        elif key in self.BTNS:
+            self._expiry[self.BTNS[key]] = now + self.hold_s
+
+    def poll(self, now: float):
+        self._expiry = {b: t for b, t in self._expiry.items() if t > now}
+        mask = 0
+        for b in self._expiry:
+            mask |= 1 << b
+        return mask
+
+
+def open_input_source(prefer: str = "auto", device: str | None = None, hold_ms: int = 150):
+    if prefer == "none":
+        return None
+    if prefer in ("auto", "gamepad"):
+        try:
+            src = GamepadSource(device).open()
+            print(f"  Input: gamepad {src.name}")
+            return src
+        except Exception as e:
+            if prefer == "gamepad":
+                raise
+            print(f"  Input: no gamepad ({e}); using keyboard")
+    src = KeyboardSource(hold_ms).open()
+    print("  Input: keyboard (raw terminal)")
+    return src
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--gamepad", action="store_true", help="force a controller via evdev/pygame")
+    g.add_argument("--keyboard", action="store_true", help="force raw-terminal keyboard")
+    p.add_argument("--device", help="explicit evdev path (/dev/input/eventN) or pygame index (0, 1...)")
+    p.add_argument("--hold", type=int, default=150,
+                   help="keyboard: ms a key stays held before auto-release (default 150)")
+    args = p.parse_args()
+
+    prefer = "gamepad" if args.gamepad else "keyboard" if args.keyboard else "auto"
+    with ri.session() as dev:
+        src = open_input_source(prefer, args.device, args.hold)
+        print("--- driving (q / Ctrl-C to quit) ---")
+        last = -1
+        try:
+            while True:
+                now = time.monotonic()
+                mask = src.poll(now)
+                if mask is None:
+                    break
+                if mask != last:
+                    dev.transport.write_mask(mask)
+                    last = mask
+                time.sleep(0.005)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if src:
+                src.close()
+    print("\nCleared shadow cell. Bye.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/remote_input.py
+++ b/scripts/remote_input.py
@@ -1,0 +1,266 @@
+"""Remote button injection backend — the shared engine for driving the device.
+
+How it works
+------------
+A `REMOTE_INPUT` firmware build OR's a 32-bit "shadow" word at
+`SRAM_REMOTE_INPUT_ADDR` (0x2001FFF4, DTCM) into its live button state every
+input poll, so a debug-probe write to that cell is indistinguishable from a
+physical press.
+
+The whole point of this module is **one persistent OpenOCD connection** to keep
+overhead low and avoid repeating commands.
+"""
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+
+# --- Shadow cell: keep in sync with Core/Inc/gw_buttons.h ---
+SHADOW_ADDR = 0x2001FFF4
+
+# --- Button bits: keep in sync with input_button_t enum order:
+#     UP, DOWN, LEFT, RIGHT, A, B, START, SELECT, PAUSE, GAME, TIME, PWR
+BTN_UP = 0
+BTN_DOWN = 1
+BTN_LEFT = 2
+BTN_RIGHT = 3
+BTN_A = 4
+BTN_B = 5
+BTN_START = 6
+BTN_SELECT = 7
+BTN_PAUSE = 8
+BTN_GAME = 9
+BTN_TIME = 10
+BTN_PWR = 11
+
+# Name <-> bit, handy for CLIs / logging.
+NAMES = {
+    "UP": BTN_UP, "DOWN": BTN_DOWN, "LEFT": BTN_LEFT, "RIGHT": BTN_RIGHT,
+    "A": BTN_A, "B": BTN_B, "START": BTN_START, "SELECT": BTN_SELECT,
+    "PAUSE": BTN_PAUSE, "GAME": BTN_GAME, "TIME": BTN_TIME, "PWR": BTN_PWR,
+}
+BIT_NAME = {v: k for k, v in NAMES.items()}
+
+# Default tap timing.
+TAP_MS = 80
+GAP_MS = 120
+
+
+def mask_of(keys) -> int:
+    """OR a button or iterable of buttons into a single bitmask."""
+    if isinstance(keys, int):
+        keys = (keys,)
+    m = 0
+    for k in keys:
+        m |= 1 << int(k)
+    return m
+
+
+def mask_str(mask: int) -> str:
+    """Human-readable button list for a mask (e.g. 'LEFT+GAME')."""
+    parts = [BIT_NAME[b] for b in range(16) if mask & (1 << b)]
+    return "+".join(parts) if parts else "none"
+
+
+class InputTransport:
+    """Abstract way to assert a raw button bitmask on the device."""
+
+    def open(self) -> "InputTransport":
+        return self
+
+    def close(self) -> None:
+        pass
+
+    def reconnect(self) -> "InputTransport":
+        """Re-establish the link after a device reset."""
+        try:
+            self.close()
+        except Exception:
+            pass
+        return self.open()
+
+    def write_mask(self, mask: int) -> None:
+        raise NotImplementedError
+
+
+class ShadowCellTransport(InputTransport):
+    """Writes the button bitmask to the SWD shadow cell over one OpenOCD socket."""
+
+    def __init__(self, backend=None, addr: int = SHADOW_ADDR):
+        self._backend = backend
+        self._own_backend = backend is None
+        self._addr = addr
+
+    def open(self) -> "ShadowCellTransport":
+        if self._backend is None:
+            from gnwmanager.ocdbackend.openocd_backend import OpenOCDBackend
+            self._backend = OpenOCDBackend()
+            self._backend.open()
+        return self
+
+    def close(self) -> None:
+        if self._own_backend and self._backend is not None:
+            self._backend.close()
+            self._backend = None
+
+    def reconnect(self) -> "ShadowCellTransport":
+        if not self._own_backend:
+            raise RuntimeError("cannot reconnect a shared (externally-owned) backend")
+        self._backend = None
+        return self.open()
+
+    def write_mask(self, mask: int) -> None:
+        self._backend.write_uint32(self._addr, mask & 0xFFFFFFFF)
+
+    @property
+    def backend(self):
+        """The live OpenOCD backend (for memory reads)."""
+        return self._backend
+
+
+class _Hold:
+    """Context manager that holds a mask down for the duration of a `with` block."""
+
+    def __init__(self, dev: "RemoteInput", mask: int):
+        self._dev = dev
+        self._mask = mask
+
+    def __enter__(self) -> "_Hold":
+        self._dev._add_held(self._mask)
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        self._dev._remove_held(self._mask)
+        return False
+
+
+class _NullCM:
+    """Inert context manager so `with button_press([X])` is harmless when hold=False."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class RemoteInput:
+    """Press buttons on the device over a persistent connection."""
+
+    def __init__(self, transport: InputTransport | None = None):
+        self.transport = transport or ShadowCellTransport()
+        self._held = 0
+        self._open = False
+
+    def open(self) -> "RemoteInput":
+        self.transport.open()
+        self._open = True
+        self._held = 0
+        self.transport.write_mask(0)
+        return self
+
+    def close(self) -> None:
+        if self._open:
+            try:
+                self.transport.write_mask(0)
+            finally:
+                self.transport.close()
+                self._open = False
+
+    def __enter__(self) -> "RemoteInput":
+        return self.open()
+
+    def __exit__(self, *exc) -> bool:
+        self.close()
+        return False
+
+    @property
+    def backend(self):
+        return getattr(self.transport, "backend", None)
+
+    def reconnect(self) -> "RemoteInput":
+        self._held = 0
+        self.transport.reconnect()
+        self._open = True
+        try:
+            self.transport.write_mask(0)
+        except Exception:
+            pass
+        return self
+
+    def _flush(self, transient: int = 0) -> None:
+        self.transport.write_mask(self._held | transient)
+
+    def _add_held(self, mask: int) -> None:
+        self._held |= mask
+        self._flush()
+
+    def _remove_held(self, mask: int) -> None:
+        self._held &= ~mask
+        self._flush()
+
+    def tap(self, keys, repeat: int = 1, tap_ms: int = TAP_MS, gap_ms: int = GAP_MS) -> None:
+        """Press and release `keys` cleanly `repeat` times."""
+        mask = mask_of(keys)
+        for i in range(repeat):
+            self._flush(mask)
+            time.sleep(tap_ms / 1000.0)
+            self._flush(0)
+            if i + 1 < repeat:
+                time.sleep(gap_ms / 1000.0)
+
+    def hold(self, keys) -> _Hold:
+        """Return a context manager that holds `keys` for the `with` block."""
+        return _Hold(self, mask_of(keys))
+
+    def button_press(self, keys, hold: bool = False, repeat: int = 1):
+        if hold:
+            return self.hold(keys)
+        self.tap(keys, repeat=repeat)
+        return _NullCM()
+
+    def press(self, keys, **kw):
+        return self.button_press(keys, **kw)
+
+
+# --- module-level convenience over a single default instance -------------
+_default: RemoteInput | None = None
+
+
+def connect(transport: InputTransport | None = None) -> RemoteInput:
+    global _default
+    if _default is None:
+        _default = RemoteInput(transport)
+        _default.open()
+    return _default
+
+
+def close() -> None:
+    global _default
+    if _default is not None:
+        _default.close()
+        _default = None
+
+
+def _require() -> RemoteInput:
+    if _default is None:
+        raise RuntimeError("call remote_input.connect() first")
+    return _default
+
+
+def button_press(keys, hold: bool = False, repeat: int = 1):
+    return _require().button_press(keys, hold=hold, repeat=repeat)
+
+
+def tap(keys, repeat: int = 1):
+    _require().tap(keys, repeat=repeat)
+
+
+@contextmanager
+def session(transport: InputTransport | None = None):
+    dev = RemoteInput(transport)
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()


### PR DESCRIPTION
This PR introduces a remote input and harness toolkit under the  scripts/  directory, allowing manual keyboard/gamepad control and SWD-based closed-loop automation (disabled by default). 
  
### 1.  scripts/remote_input.py
  
What it does: 
- Serves as the backend for injecting button presses into the device over SWD.

How it works: 
- Opens a persistent OpenOCD session via  gnwmanager  to write button bitmasks to the DTCM RAM shadow register ( 0x2001FFF4 ). A persistent socket eliminates the connection spin-up overhead, keeping input response latency under ~80 ms to prevent accidental long-press loops. 
  
### 2.  scripts/harness.py
  
What it does:
- Provides a lightweight foundation for writing automated tests or other debug/interaction scripts.
- It acts as a safety layer for script loops (e.g., automated test loops, GUI polling loops, or live telemetry feeders) interacting with the hardware. It simplifies symbol resolution and memory reads, while preventing script deadlocks and handling connection drops

Key Features:
- Symbol Resolution: Resolves symbol addresses (handles LTO mangling) directly from build/gw_retro_go.elf using arm-none-eabi-nm .
- Loop Verification ( retrogo_running ): Halts and resumes the MCU to verify if  uwTick  is actively incrementing, confirming that the main emulator loop is executing.
- Robust Polling ( wait_u32 ): Polls registers across target resets and re-establishes the probe connection.  
- Time Budgets: Implements SIGALRM-based wall-clock timeouts so wedged debug-probe operations abort cleanly instead of hanging.
  

### 3.  scripts/remote_control.py
  
What it does: 
- Pygame/SDL: Fallback on Linux and default backend for macOS/Windows, utilizing Pygame's joystick library with a headless dummy video driver to run directly from command-line shells.
- Cross-Platform Keyboard: Uses  msvcrt  on Windows to read key presses and map extended arrow scan codes, falling back to Unix  termios  and  tty  on other platforms.
- Linux evdev : Uses standard Linux character event devices for kernel-level inputs.