### PR TITLE
Web-Based Retro-Go Builder specific changes

### DIFF
--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -26,6 +26,7 @@ on:
       - 'Core/Src/retro-go/gw_layout_superblock.*'
       - 'Core/Inc/retro-go/gw_layout_superblock.h'
       - 'Core/Src/retro-go/rg_frogfs.c'
+      - 'Core/Src/gw_littlefs.c'
       - 'Makefile'
       - 'Makefile.common'
       - 'STM32H7B0VBTx_FLASH.ld'

--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -14,11 +14,6 @@ name: web-artifacts (POC)
 on:
   workflow_dispatch:
     inputs:
-      model:
-        description: "GNW_TARGET (intflash blob is model-agnostic; affects default extflash size only)"
-        default: mario
-        type: choice
-        options: [mario, zelda]
       builder_image:
         description: "retro-go-sd builder image"
         default: sylverb/retro-go-sd-builder:v1.5
@@ -46,7 +41,6 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     env:
-      MODEL: ${{ inputs.model || 'mario' }}
       BUILDER_IMAGE: ${{ inputs.builder_image || 'sylverb/retro-go-sd-builder:v1.5' }}
     steps:
       - name: Checkout web-builder-flash (recursive submodules)
@@ -59,41 +53,43 @@ jobs:
       - name: Build SD_CARD=0 sd_content + superblock blob (in builder image)
         run: |
           set -euo pipefail
-          # All 12 languages baked (Latin + ru default ON; CJK enabled here) so one
-          # blob serves every language — the browser packs the selected lang blob +
-          # font. CJK fonts land in sd_content (not the intflash blob).
+          # ONE universal blob: GNW_TARGET is irrelevant (LittleFS geometry is now
+          # superblock-driven, not baked), so we don't pass it (defaults to mario,
+          # immaterial). All 12 languages baked (Latin+ru default ON; CJK enabled
+          # here); the browser packs the selected lang blob + font. CJK fonts land in
+          # sd_content (not the intflash blob).
           docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/opt/workdir" \
             "$BUILDER_IMAGE" \
-            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 GNW_TARGET=$MODEL ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 create_sd_data build/gw_retro_go_intflash.bin"
+            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 create_sd_data build/gw_retro_go_intflash.bin"
 
       - name: Pack web-artifacts.zip + manifest.json
         id: pack
         run: |
           set -euo pipefail
           SHORT="${GITHUB_SHA::7}"
-          ID="web-builder-flash-${SHORT}-${MODEL}"
+          ID="web-builder-flash-${SHORT}"
           {
             echo "short=$SHORT"
             echo "id=$ID"
-            echo "tag=web-artifacts-${SHORT}-${MODEL}"
+            echo "tag=web-artifacts-${SHORT}"
           } >> "$GITHUB_OUTPUT"
           python3 scripts/flasher/pack_bundle.py \
             --sd-content sd_content --blob build/gw_retro_go_intflash.bin \
             --out _bundle --id "$ID" --ref web-builder-flash \
-            --sha "$GITHUB_SHA" --model "$MODEL" \
+            --sha "$GITHUB_SHA" \
             --built-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Publish as a prerelease asset
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.pack.outputs.tag }}
-          name: "web-artifacts — ${{ env.MODEL }} @ ${{ steps.pack.outputs.short }}"
+          name: "web-artifacts @ ${{ steps.pack.outputs.short }}"
           prerelease: true
           body: |
             Build inputs for the gnw-web-builder browser flasher (FrogFS `SD_CARD=0`
-            firmware blob + default content). Not an end-user release.
+            firmware blob + default content). One universal blob — the host sets
+            extflash geometry via the superblock. Not an end-user release.
 
-            - model: `${{ env.MODEL }}`
             - commit: `${{ github.sha }}`
           files: |
             _bundle/web-artifacts.zip

--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -60,21 +60,24 @@ jobs:
           # ALL capabilities baked ON — COVERFLOW, CHEAT_CODES, SHARED_HIBERNATE_SAVESTATE
           # (screenshots default on; splash off) — so one blob set serves every feature
           # (~246 KB, fits the single 256 KB bank); the browser adds covers/cheats CONTENT
-          # later. All 12 languages baked. sd_content (incl. cores) is bank-independent →
-          # built once in the bank-2 pass and shared (make clean keeps sd_content/).
-          # MAX_CHEAT_CODES=13 is passed on the command line (NOT a Makefile edit): the
-          # stock Makefile only defines it for SD_CARD=1, so CHEAT_CODES=1 SD_CARD=0 needs
-          # it supplied here to compile — matches the SD build's value.
+          # later. All 12 languages baked. NOTE: `make clean` wipes BUILD_DIR (build/)
+          # AND SD_FOLDER (sd_content/) — so (a) stash each blob in _blobs/ (outside the
+          # cleaned dirs) right after its build, and (b) run create_sd_data in the LAST
+          # pass so sd_content survives to packing. Cores are bank-independent, so taking
+          # them from the bank-2 ELF is fine. MAX_CHEAT_CODES=13 is passed on the command
+          # line (NOT a Makefile edit): the stock Makefile only defines it for SD_CARD=1,
+          # so CHEAT_CODES=1 SD_CARD=0 needs it supplied here — matches the SD value.
           FLAGS="SD_CARD=0 COVERFLOW=1 CHEAT_CODES=1 MAX_CHEAT_CODES=13 SHARED_HIBERNATE_SAVESTATE=1 DISABLE_SPLASH_SCREEN=1 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1"
           docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/opt/workdir" \
             "$BUILDER_IMAGE" \
             bash -l -c "set -e
-              make clean
-              make -j\$(nproc) INTFLASH_BANK=2 $FLAGS create_sd_data build/gw_retro_go_intflash.bin
-              cp build/gw_retro_go_intflash.bin build/gw_retro_go_intflash_bank2.bin
+              mkdir -p _blobs
               make clean
               make -j\$(nproc) INTFLASH_BANK=1 $FLAGS build/gw_retro_go_intflash.bin
-              cp build/gw_retro_go_intflash.bin build/gw_retro_go_intflash_bank1.bin"
+              cp build/gw_retro_go_intflash.bin _blobs/gw_retro_go_intflash_bank1.bin
+              make clean
+              make -j\$(nproc) INTFLASH_BANK=2 $FLAGS create_sd_data build/gw_retro_go_intflash.bin
+              cp build/gw_retro_go_intflash.bin _blobs/gw_retro_go_intflash_bank2.bin"
 
       - name: Pack web-artifacts.zip + manifest.json
         id: pack
@@ -89,8 +92,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           python3 scripts/flasher/pack_bundle.py \
             --sd-content sd_content \
-            --blob-bank1 build/gw_retro_go_intflash_bank1.bin \
-            --blob-bank2 build/gw_retro_go_intflash_bank2.bin \
+            --blob-bank1 _blobs/gw_retro_go_intflash_bank1.bin \
+            --blob-bank2 _blobs/gw_retro_go_intflash_bank2.bin \
             --out _bundle --id "$ID" --ref web-builder-flash \
             --sha "$GITHUB_SHA" \
             --built-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -1,0 +1,97 @@
+# Web-flasher artifact producer (POC for gnw-web-builder).
+#
+# Builds the FrogFS (SD_CARD=0) firmware blob (with the layout superblock) + the
+# default sd_content, packs them into web-artifacts.zip, and publishes it as a
+# PRERELEASE asset (neutral name; the gnw-web-builder app consumes it via the
+# Releases API + the asset's browser_download_url, CORS-friendly).
+#
+# Scope: lives only on web-builder-flash; do NOT merge to main. Triggered by pushes
+# to web-builder-flash that touch the firmware/workflow (a full retro-go build is
+# heavy), plus manual dispatch. (workflow_dispatch won't appear in the Actions UI
+# while this is off the default branch — the push trigger is how you test it.)
+name: web-artifacts (POC)
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "GNW_TARGET (intflash blob is model-agnostic; affects default extflash size only)"
+        default: mario
+        type: choice
+        options: [mario, zelda]
+      builder_image:
+        description: "retro-go-sd builder image"
+        default: sylverb/retro-go-sd-builder:v1.5
+        type: string
+  push:
+    branches: [web-builder-flash]
+    paths:
+      - '.github/workflows/flasher-artifacts.yml'
+      - 'scripts/flasher/**'
+      - 'Core/Src/retro-go/gw_layout_superblock.*'
+      - 'Core/Inc/retro-go/gw_layout_superblock.h'
+      - 'Core/Src/retro-go/rg_frogfs.c'
+      - 'Makefile'
+      - 'Makefile.common'
+      - 'STM32H7B0VBTx_FLASH.ld'
+
+permissions:
+  contents: write   # to create the prerelease + upload assets
+
+concurrency:
+  group: web-artifacts
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    env:
+      MODEL: ${{ inputs.model || 'mario' }}
+      BUILDER_IMAGE: ${{ inputs.builder_image || 'sylverb/retro-go-sd-builder:v1.5' }}
+    steps:
+      - name: Checkout web-builder-flash (recursive submodules)
+        uses: actions/checkout@v4
+        with:
+          ref: web-builder-flash
+          submodules: recursive   # MUST be recursive — cores/MSX/etc. live in submodules
+          fetch-depth: 1
+
+      - name: Build SD_CARD=0 sd_content + superblock blob (in builder image)
+        run: |
+          set -euo pipefail
+          docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/opt/workdir" \
+            "$BUILDER_IMAGE" \
+            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 GNW_TARGET=$MODEL create_sd_data build/gw_retro_go_intflash.bin"
+
+      - name: Pack web-artifacts.zip + manifest.json
+        id: pack
+        run: |
+          set -euo pipefail
+          SHORT="${GITHUB_SHA::7}"
+          ID="web-builder-flash-${SHORT}-${MODEL}"
+          {
+            echo "short=$SHORT"
+            echo "id=$ID"
+            echo "tag=web-artifacts-${SHORT}-${MODEL}"
+          } >> "$GITHUB_OUTPUT"
+          python3 scripts/flasher/pack_bundle.py \
+            --sd-content sd_content --blob build/gw_retro_go_intflash.bin \
+            --out _bundle --id "$ID" --ref web-builder-flash \
+            --sha "$GITHUB_SHA" --model "$MODEL" \
+            --built-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      - name: Publish as a prerelease asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.pack.outputs.tag }}
+          name: "web-artifacts — ${{ env.MODEL }} @ ${{ steps.pack.outputs.short }}"
+          prerelease: true
+          body: |
+            Build inputs for the gnw-web-builder browser flasher (FrogFS `SD_CARD=0`
+            firmware blob + default content). Not an end-user release.
+
+            - model: `${{ env.MODEL }}`
+            - commit: `${{ github.sha }}`
+          files: |
+            _bundle/web-artifacts.zip
+            _bundle/manifest.json

--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -59,9 +59,12 @@ jobs:
       - name: Build SD_CARD=0 sd_content + superblock blob (in builder image)
         run: |
           set -euo pipefail
+          # All 12 languages baked (Latin + ru default ON; CJK enabled here) so one
+          # blob serves every language — the browser packs the selected lang blob +
+          # font. CJK fonts land in sd_content (not the intflash blob).
           docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/opt/workdir" \
             "$BUILDER_IMAGE" \
-            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 GNW_TARGET=$MODEL create_sd_data build/gw_retro_go_intflash.bin"
+            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 GNW_TARGET=$MODEL ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 create_sd_data build/gw_retro_go_intflash.bin"
 
       - name: Pack web-artifacts.zip + manifest.json
         id: pack

--- a/.github/workflows/flasher-artifacts.yml
+++ b/.github/workflows/flasher-artifacts.yml
@@ -50,17 +50,31 @@ jobs:
           submodules: recursive   # MUST be recursive — cores/MSX/etc. live in submodules
           fetch-depth: 1
 
-      - name: Build SD_CARD=0 sd_content + superblock blob (in builder image)
+      - name: Build SD_CARD=0 sd_content + bank1/bank2 blobs (in builder image)
         run: |
           set -euo pipefail
-          # ONE universal blob: GNW_TARGET is irrelevant (LittleFS geometry is now
-          # superblock-driven, not baked), so we don't pass it (defaults to mario,
-          # immaterial). All 12 languages baked (Latin+ru default ON; CJK enabled
-          # here); the browser packs the selected lang blob + font. CJK fonts land in
-          # sd_content (not the intflash blob).
+          # Two linked blobs: bank 1 (overwrite stock) and bank 2 (keep stock in bank 1
+          # for dual-boot/recovery). The bank IS the intflash link address (0x08000000 /
+          # 0x08100000), so it can't be a runtime patch — hence two blobs. GNW_TARGET is
+          # omitted (LittleFS geometry is superblock-driven; docs/BINARY_PATCHING.md).
+          # ALL capabilities baked ON — COVERFLOW, CHEAT_CODES, SHARED_HIBERNATE_SAVESTATE
+          # (screenshots default on; splash off) — so one blob set serves every feature
+          # (~246 KB, fits the single 256 KB bank); the browser adds covers/cheats CONTENT
+          # later. All 12 languages baked. sd_content (incl. cores) is bank-independent →
+          # built once in the bank-2 pass and shared (make clean keeps sd_content/).
+          # MAX_CHEAT_CODES=13 is passed on the command line (NOT a Makefile edit): the
+          # stock Makefile only defines it for SD_CARD=1, so CHEAT_CODES=1 SD_CARD=0 needs
+          # it supplied here to compile — matches the SD build's value.
+          FLAGS="SD_CARD=0 COVERFLOW=1 CHEAT_CODES=1 MAX_CHEAT_CODES=13 SHARED_HIBERNATE_SAVESTATE=1 DISABLE_SPLASH_SCREEN=1 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1"
           docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/opt/workdir" \
             "$BUILDER_IMAGE" \
-            bash -l -c "make clean; make -j\$(nproc) SD_CARD=0 ZH_CN=1 ZH_TW=1 KO_KR=1 JA_JP=1 create_sd_data build/gw_retro_go_intflash.bin"
+            bash -l -c "set -e
+              make clean
+              make -j\$(nproc) INTFLASH_BANK=2 $FLAGS create_sd_data build/gw_retro_go_intflash.bin
+              cp build/gw_retro_go_intflash.bin build/gw_retro_go_intflash_bank2.bin
+              make clean
+              make -j\$(nproc) INTFLASH_BANK=1 $FLAGS build/gw_retro_go_intflash.bin
+              cp build/gw_retro_go_intflash.bin build/gw_retro_go_intflash_bank1.bin"
 
       - name: Pack web-artifacts.zip + manifest.json
         id: pack
@@ -74,7 +88,9 @@ jobs:
             echo "tag=web-artifacts-${SHORT}"
           } >> "$GITHUB_OUTPUT"
           python3 scripts/flasher/pack_bundle.py \
-            --sd-content sd_content --blob build/gw_retro_go_intflash.bin \
+            --sd-content sd_content \
+            --blob-bank1 build/gw_retro_go_intflash_bank1.bin \
+            --blob-bank2 build/gw_retro_go_intflash_bank2.bin \
             --out _bundle --id "$ID" --ref web-builder-flash \
             --sha "$GITHUB_SHA" \
             --built-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/Core/Inc/retro-go/gw_layout_superblock.h
+++ b/Core/Inc/retro-go/gw_layout_superblock.h
@@ -19,13 +19,14 @@
 #include <stdint.h>
 
 #define GNW_LAYOUT_MAGIC    0x424C5747u  /* "GWLB" — LE bytes 47 57 4C 42 */
-#define GNW_LAYOUT_VERSION  1u
+#define GNW_LAYOUT_VERSION  2u
 
 /* flags bits: each marks "this override field is authoritative" (so a real 0 is
  * distinguishable from "unset → use runtime default"). */
 #define GNW_LAYOUT_FLAG_FROGFS_OFFSET    (1u << 0)
 #define GNW_LAYOUT_FLAG_EXTFLASH_SIZE    (1u << 1)
 #define GNW_LAYOUT_FLAG_RESERVED_OFFSET  (1u << 2)
+#define GNW_LAYOUT_FLAG_LITTLEFS_LENGTH  (1u << 3)
 
 #pragma pack(push, 1)
 typedef struct {
@@ -36,9 +37,10 @@ typedef struct {
     uint32_t frogfs_length;    /* 0x0C  packed image size (0 = unknown) */
     uint32_t extflash_size;    /* 0x10  total extflash bytes (override; 0 = OSPI_GetFlashSize) */
     uint32_t reserved_offset;  /* 0x14  bottom-reserved bytes (override; 0 = get_ofw_extflash_size) */
-    uint32_t flags;            /* 0x18  GNW_LAYOUT_FLAG_* */
-    uint32_t crc32;            /* 0x1C  crc32_le(0, this, 0x1C) */
-} GnwLayoutSuperblock;          /* 32 bytes */
+    uint32_t littlefs_length;  /* 0x18  LittleFS partition bytes (override; 0 = linker default) */
+    uint32_t flags;            /* 0x1C  GNW_LAYOUT_FLAG_* */
+    uint32_t crc32;            /* 0x20  crc32_le(0, this, 0x20) */
+} GnwLayoutSuperblock;          /* 36 bytes */
 #pragma pack(pop)
 
 extern const GnwLayoutSuperblock g_layout_superblock;
@@ -53,3 +55,11 @@ uint32_t gw_layout_frogfs_addr(void);
 /* Bytes reserved at the bottom of extflash: superblock override when valid +
  * set, otherwise get_ofw_extflash_size() (bank-1 OFW metadata). */
 uint32_t gw_layout_reserved_size(void);
+
+/* LittleFS partition (writable saves region; grows DOWN from the top of extflash).
+ * top   = 0x90000000 + extflash_size  (superblock/runtime), else linker __FILESYSTEM_END__.
+ * bytes = littlefs_length             (superblock override),  else linker
+ *         (__FILESYSTEM_END__ - __FILESYSTEM_START__). The host derives both from
+ *         the probe-detected chip size + the FrogFS image it built. */
+uint32_t gw_layout_littlefs_top(void);
+uint32_t gw_layout_littlefs_size(void);

--- a/Core/Inc/retro-go/gw_layout_superblock.h
+++ b/Core/Inc/retro-go/gw_layout_superblock.h
@@ -1,0 +1,55 @@
+/*
+ * Layout superblock — a tiny, magic-located struct compiled into any FrogFS
+ * firmware (SD_CARD=0; bank-agnostic — present in bank-1 and bank-2 builds) that
+ * makes the FrogFS asset location (and optional extflash geometry) patchable in a
+ * prebuilt binary, so ONE binary serves any extflash offset/size.
+ *
+ * A plain `make` build bakes frogfs_offset from the linker's __EXTFLASH_OFFSET__
+ * and leaves crc32 = 0 → the firmware's CRC check fails and it falls back to the
+ * linker defaults (== today's behavior). A host patcher (browser app or
+ * patch_superblock.py) locates this struct by magic, writes the fields, and
+ * recomputes crc32; the firmware then honors the overrides. Never bricks: any
+ * invalid/absent superblock degrades to exactly the unpatched behavior.
+ *
+ * See docs/BINARY_PATCHING.md (in the gnw-web-builder repo).
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define GNW_LAYOUT_MAGIC    0x424C5747u  /* "GWLB" — LE bytes 47 57 4C 42 */
+#define GNW_LAYOUT_VERSION  1u
+
+/* flags bits: each marks "this override field is authoritative" (so a real 0 is
+ * distinguishable from "unset → use runtime default"). */
+#define GNW_LAYOUT_FLAG_FROGFS_OFFSET    (1u << 0)
+#define GNW_LAYOUT_FLAG_EXTFLASH_SIZE    (1u << 1)
+#define GNW_LAYOUT_FLAG_RESERVED_OFFSET  (1u << 2)
+
+#pragma pack(push, 1)
+typedef struct {
+    uint32_t magic;            /* 0x00  GNW_LAYOUT_MAGIC */
+    uint16_t version;          /* 0x04  GNW_LAYOUT_VERSION */
+    uint16_t struct_size;      /* 0x06  sizeof(GnwLayoutSuperblock) == 32 */
+    uint32_t frogfs_offset;    /* 0x08  FrogFS base = 0x90000000 + frogfs_offset */
+    uint32_t frogfs_length;    /* 0x0C  packed image size (0 = unknown) */
+    uint32_t extflash_size;    /* 0x10  total extflash bytes (override; 0 = OSPI_GetFlashSize) */
+    uint32_t reserved_offset;  /* 0x14  bottom-reserved bytes (override; 0 = get_ofw_extflash_size) */
+    uint32_t flags;            /* 0x18  GNW_LAYOUT_FLAG_* */
+    uint32_t crc32;            /* 0x1C  crc32_le(0, this, 0x1C) */
+} GnwLayoutSuperblock;          /* 32 bytes */
+#pragma pack(pop)
+
+extern const GnwLayoutSuperblock g_layout_superblock;
+
+/* True iff magic + version + struct_size + crc32 all validate (cached). */
+bool gw_layout_valid(void);
+
+/* FrogFS XiP base: 0x90000000 + frogfs_offset when valid + override set;
+ * otherwise the linker default (uint32_t)&__EXTFLASH_START__. */
+uint32_t gw_layout_frogfs_addr(void);
+
+/* Bytes reserved at the bottom of extflash: superblock override when valid +
+ * set, otherwise get_ofw_extflash_size() (bank-1 OFW metadata). */
+uint32_t gw_layout_reserved_size(void);

--- a/Core/Src/gw_littlefs.c
+++ b/Core/Src/gw_littlefs.c
@@ -5,6 +5,9 @@
 #include <string.h>
 #include <time.h>
 #include "gw_littlefs.h"
+#if SD_CARD == 0
+#include "gw_layout_superblock.h"
+#endif
 #include "gw_sleep.h"
 #include "porting/lib/littlefs/lfs.h"
 #include "tamp/compressor.h"
@@ -277,7 +280,15 @@ static void corrupt_filesystem_screen(void){
  * Initialize and mount the filesystem. Format the filesystem if unmountable (and then reattempt mount).
  */
 void fs_init(void){
+#if SD_CARD == 0
+    // FrogFS (flash) build: the LittleFS partition geometry comes from the layout
+    // superblock (host-determined from the probe-detected chip size + the FrogFS
+    // image), falling back to the linker symbols when unpatched. This is what lets
+    // one binary serve any extflash size. See gw_layout_superblock.h.
+    lfs_cfg.context = (void *)gw_layout_littlefs_top();
+#else
     lfs_cfg.context = &__FILESYSTEM_END__;  // We work "backwards"
+#endif
     lfs_cfg.block_size = OSPI_GetSmallestEraseSize();
     lfs_cfg.block_count = 0;
 
@@ -285,7 +296,11 @@ void fs_init(void){
     // this should only happen on the first boot
     if (lfs_mount(&lfs, &lfs_cfg)) {
         corrupt_filesystem_screen();
+#if SD_CARD == 0
+        lfs_cfg.block_count = gw_layout_littlefs_size() / lfs_cfg.block_size;
+#else
         lfs_cfg.block_count = (&__FILESYSTEM_END__ - &__FILESYSTEM_START__) / lfs_cfg.block_size;
+#endif
         // If we get here, it means that the user chose to reformat the filesystem.
         assert(lfs_mount(&lfs, &lfs_cfg) == 0);
     }

--- a/Core/Src/gw_littlefs.c
+++ b/Core/Src/gw_littlefs.c
@@ -244,6 +244,10 @@ static void release_file_handle(fs_file_t *file){
     assert(0);  // Should never reach here.
 }
 
+/* gnw-web-builder DIAGNOSTIC: mount-failure detail, rendered on the corrupt screen. */
+static char g_fs_diag1[48] = "";
+static char g_fs_diag2[48] = "";
+
 static void corrupt_filesystem_screen(void){
     char buf[64];
     int idle_s = uptime_get();
@@ -257,6 +261,10 @@ static void corrupt_filesystem_screen(void){
         int steps = uptime_get() - idle_s;
         sprintf(buf, "%ds to sleep", 600 - steps);
         odroid_overlay_draw_text_line(4, 29 * 8 - 4, strlen(buf) * 8, buf, C_RED, curr_colors->bg_c);
+        if (g_fs_diag1[0])
+            odroid_overlay_draw_text_line(4, 26 * 8 - 4, strlen(g_fs_diag1) * 8, g_fs_diag1, C_RED, curr_colors->bg_c);
+        if (g_fs_diag2[0])
+            odroid_overlay_draw_text_line(4, 27 * 8 - 4, strlen(g_fs_diag2) * 8, g_fs_diag2, C_RED, curr_colors->bg_c);
 
         lcd_sync();
         lcd_swap();
@@ -294,7 +302,18 @@ void fs_init(void){
 
     // reformat if we can't mount the fs
     // this should only happen on the first boot
-    if (lfs_mount(&lfs, &lfs_cfg)) {
+    int mount_err = lfs_mount(&lfs, &lfs_cfg);
+    if (mount_err) {
+#if SD_CARD == 0
+        /* gnw-web-builder DIAGNOSTIC: show the mount code + the geometry actually used.
+         * err -22 = LFS_ERR_INVAL (config/block_size); -84 = LFS_ERR_CORRUPT (location/data).
+         * valid=1 means the layout superblock took effect (else baked linker fallback). */
+        snprintf(g_fs_diag1, sizeof(g_fs_diag1), "err=%d valid=%d bs=%lu",
+                 mount_err, (int)gw_layout_valid(), (unsigned long)lfs_cfg.block_size);
+        snprintf(g_fs_diag2, sizeof(g_fs_diag2), "top=%08lX sz=%lu",
+                 (unsigned long)gw_layout_littlefs_top(),
+                 (unsigned long)gw_layout_littlefs_size());
+#endif
         corrupt_filesystem_screen();
 #if SD_CARD == 0
         lfs_cfg.block_count = gw_layout_littlefs_size() / lfs_cfg.block_size;

--- a/Core/Src/retro-go/gw_layout_superblock.c
+++ b/Core/Src/retro-go/gw_layout_superblock.c
@@ -7,6 +7,7 @@
 #include "gw_layout_superblock.h"
 #include "gw_linker.h"
 #include "gw_ofw.h"
+#include "gw_flash.h"   /* OSPI_GetFlashSize() */
 #include "crc32.h"
 
 /* Lands in .rodata (included in gw_retro_go_intflash.bin) so a host can locate
@@ -23,6 +24,7 @@ const GnwLayoutSuperblock g_layout_superblock = {
     .frogfs_length   = 0u,
     .extflash_size   = 0u,
     .reserved_offset = 0u,
+    .littlefs_length = 0u,
     .flags           = GNW_LAYOUT_FLAG_FROGFS_OFFSET,
     .crc32           = 0u,
 };
@@ -34,8 +36,8 @@ bool gw_layout_valid(void)
         const GnwLayoutSuperblock *sb = &g_layout_superblock;
         bool ok = (sb->magic == GNW_LAYOUT_MAGIC)
                && (sb->version <= GNW_LAYOUT_VERSION)
-               && (sb->struct_size >= 32u)
-               && (crc32_le(0u, (const unsigned char *)sb, 0x1Cu) == sb->crc32);
+               && (sb->struct_size >= 36u)
+               && (crc32_le(0u, (const unsigned char *)sb, 0x20u) == sb->crc32);
         cached = ok ? 1 : 0;
     }
     return cached != 0;
@@ -55,6 +57,32 @@ uint32_t gw_layout_reserved_size(void)
     if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_RESERVED_OFFSET))
         return sb->reserved_offset;
     return get_ofw_extflash_size();
+}
+
+/* Total extflash size: superblock override (host-detected via the SWD probe) when
+ * set, otherwise the runtime SFDP read. */
+static uint32_t resolved_extflash_size(void)
+{
+    const GnwLayoutSuperblock *sb = &g_layout_superblock;
+    if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_EXTFLASH_SIZE) && sb->extflash_size)
+        return sb->extflash_size;
+    return OSPI_GetFlashSize();
+}
+
+uint32_t gw_layout_littlefs_top(void)
+{
+    const GnwLayoutSuperblock *sb = &g_layout_superblock;
+    if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_LITTLEFS_LENGTH))
+        return 0x90000000u + resolved_extflash_size();
+    return (uint32_t)&__FILESYSTEM_END__;
+}
+
+uint32_t gw_layout_littlefs_size(void)
+{
+    const GnwLayoutSuperblock *sb = &g_layout_superblock;
+    if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_LITTLEFS_LENGTH))
+        return sb->littlefs_length;
+    return (uint32_t)(&__FILESYSTEM_END__ - &__FILESYSTEM_START__);
 }
 
 #else

--- a/Core/Src/retro-go/gw_layout_superblock.c
+++ b/Core/Src/retro-go/gw_layout_superblock.c
@@ -1,0 +1,62 @@
+#include "main.h"
+
+/* The superblock is only meaningful for the FrogFS (flash) build; SD builds
+ * read assets from FatFs and never mount FrogFS. */
+#if SD_CARD == 0
+
+#include "gw_layout_superblock.h"
+#include "gw_linker.h"
+#include "gw_ofw.h"
+#include "crc32.h"
+
+/* Lands in .rodata (included in gw_retro_go_intflash.bin) so a host can locate
+ * it by scanning for GNW_LAYOUT_MAGIC. `used` keeps it even if LTO/GC is on.
+ * crc32 = 0 in a plain build → CRC check fails → fall back to linker defaults,
+ * which equal the patched values for the default offset (so an unpatched build
+ * behaves exactly as before). */
+__attribute__((used, aligned(4)))
+const GnwLayoutSuperblock g_layout_superblock = {
+    .magic           = GNW_LAYOUT_MAGIC,
+    .version         = GNW_LAYOUT_VERSION,
+    .struct_size     = (uint16_t)sizeof(GnwLayoutSuperblock),
+    .frogfs_offset   = (uint32_t)&__EXTFLASH_OFFSET__,
+    .frogfs_length   = 0u,
+    .extflash_size   = 0u,
+    .reserved_offset = 0u,
+    .flags           = GNW_LAYOUT_FLAG_FROGFS_OFFSET,
+    .crc32           = 0u,
+};
+
+bool gw_layout_valid(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const GnwLayoutSuperblock *sb = &g_layout_superblock;
+        bool ok = (sb->magic == GNW_LAYOUT_MAGIC)
+               && (sb->version <= GNW_LAYOUT_VERSION)
+               && (sb->struct_size >= 32u)
+               && (crc32_le(0u, (const unsigned char *)sb, 0x1Cu) == sb->crc32);
+        cached = ok ? 1 : 0;
+    }
+    return cached != 0;
+}
+
+uint32_t gw_layout_frogfs_addr(void)
+{
+    const GnwLayoutSuperblock *sb = &g_layout_superblock;
+    if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_FROGFS_OFFSET))
+        return 0x90000000u + sb->frogfs_offset;
+    return (uint32_t)&__EXTFLASH_START__;
+}
+
+uint32_t gw_layout_reserved_size(void)
+{
+    const GnwLayoutSuperblock *sb = &g_layout_superblock;
+    if (gw_layout_valid() && (sb->flags & GNW_LAYOUT_FLAG_RESERVED_OFFSET))
+        return sb->reserved_offset;
+    return get_ofw_extflash_size();
+}
+
+#else
+typedef int gw_layout_superblock_sd_stub; /* avoid empty translation unit */
+#endif /* SD_CARD == 0 */

--- a/Core/Src/retro-go/rg_frogfs.c
+++ b/Core/Src/retro-go/rg_frogfs.c
@@ -11,6 +11,7 @@
 #include "config.h"
 #include "ff.h"
 #include "gw_linker.h"
+#include "gw_layout_superblock.h"
 #include "rg_frogfs.h"
 
 static frogfs_fs_t *s_frogfs;
@@ -21,8 +22,10 @@ frogfs_fs_t *rg_frogfs_get(void)
         return s_frogfs;
 
     frogfs_config_t config = {
-        /* Image is flashed at physical EXTFLASH_OFFSET → XiP address __EXTFLASH_START__ */
-        .addr = &__EXTFLASH_START__,
+        /* FrogFS XiP base. Default == &__EXTFLASH_START__ (0x90000000 +
+         * __EXTFLASH_OFFSET__); a patched layout superblock can override it so
+         * one prebuilt binary serves any extflash offset. See gw_layout_superblock.h. */
+        .addr = (const void *)(uintptr_t)gw_layout_frogfs_addr(),
     };
 
     s_frogfs = frogfs_init(&config);

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ $(FATFS_DIR)/user_diskio_softspi.c
 FROGFS_DIR = Core/Src/porting/lib/frogfs
 FROGFS_C_SOURCES = \
 Core/Src/retro-go/rg_frogfs.c \
+Core/Src/retro-go/gw_layout_superblock.c \
 $(FROGFS_DIR)/src/frogfs.c \
 $(FROGFS_DIR)/src/decomp_raw.c
 

--- a/scripts/flasher/pack_bundle.py
+++ b/scripts/flasher/pack_bundle.py
@@ -3,9 +3,10 @@
 Release asset (NOT for end users — end users want retro-go_update.bin).
 
 Outputs into <out>/:
-  web-artifacts.zip  - gw_retro_go_intflash.bin (superblock blob) + sd_content/
-                       (default content: cores, bios, fonts, lang, logo, homebrew;
-                       covers/ and cheats/ EXCLUDED for now) + manifest.json.
+  web-artifacts.zip  - gw_retro_go_intflash_bank{1,2}.bin (two superblock blobs, one
+                       per intflash bank — bank is the link address, not a runtime
+                       patch) + sd_content/ (default content: cores, bios, fonts, lang,
+                       logo, homebrew; covers/ and cheats/ EXCLUDED for now) + manifest.json.
   manifest.json      - standalone copy, uploaded as its own release asset so the
                        web-flasher's version picker can read metadata without
                        downloading the whole zip.
@@ -47,7 +48,8 @@ def sha256(path):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--sd-content", required=True)
-    ap.add_argument("--blob", required=True)
+    ap.add_argument("--blob-bank1", required=True)  # INTFLASH_BANK=1 link (0x08000000)
+    ap.add_argument("--blob-bank2", required=True)  # INTFLASH_BANK=2 link (0x08100000)
     ap.add_argument("--out", required=True)
     ap.add_argument("--id", required=True)
     ap.add_argument("--ref", required=True)
@@ -80,6 +82,11 @@ def main():
             arc = os.path.join("sd_content", os.path.relpath(full, args.sd_content))
             members.append((full, arc.replace(os.sep, "/")))
 
+    # Two linked blobs — bank is the intflash address, not a runtime patch.
+    banks = [
+        ("bank1", "gw_retro_go_intflash_bank1.bin", args.blob_bank1, "0x08000000"),
+        ("bank2", "gw_retro_go_intflash_bank2.bin", args.blob_bank2, "0x08100000"),
+    ]
     manifest = {
         "id": args.id,
         "ref": args.ref,
@@ -88,10 +95,15 @@ def main():
         "superblock": True,
         "builtAt": args.built_at,
         "asset": ZIP_NAME,
-        "blob": "gw_retro_go_intflash.bin",
+        "blobs": {
+            bank: {"file": fname, "intflashAddr": addr, "bytes": os.path.getsize(path)}
+            for bank, fname, path, addr in banks
+        },
+        # Capabilities baked into the blobs (content like covers/cheats is added later
+        # by the browser into the FrogFS; these flags just enable the firmware paths).
+        "capabilities": ["coverflow", "cheatCodes", "screenshot", "sharedHibernateSavestate"],
         "cores": cores,
         "fileCount": len(members),
-        "blobBytes": os.path.getsize(args.blob),
     }
 
     # fixed timestamp → reproducible-ish zips
@@ -109,7 +121,8 @@ def main():
             zf.writestr(zi, f.read())
 
     with zipfile.ZipFile(zip_path, "w") as zf:
-        add_file(zf, args.blob, "gw_retro_go_intflash.bin")
+        for _bank, fname, path, _addr in banks:
+            add_file(zf, path, fname)
         for full, arc in members:
             add_file(zf, full, arc)
         add_bytes(zf, "manifest.json", json.dumps(manifest, indent=2).encode())

--- a/scripts/flasher/pack_bundle.py
+++ b/scripts/flasher/pack_bundle.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Assemble a web-flasher artifact from a SD_CARD=0 build, published as a GitHub
+Release asset (NOT for end users — end users want retro-go_update.bin).
+
+Outputs into <out>/:
+  web-artifacts.zip  - gw_retro_go_intflash.bin (superblock blob) + sd_content/
+                       (default content: cores, bios, fonts, lang, logo, homebrew;
+                       covers/ and cheats/ EXCLUDED for now) + manifest.json.
+  manifest.json      - standalone copy, uploaded as its own release asset so the
+                       web-flasher's version picker can read metadata without
+                       downloading the whole zip.
+
+The zip is a matched set: the cores are objcopy slices of THIS exact ELF, so the
+blob and sd_content must ship together. Consumed by gnw-web-builder (merge
+sd_content + user ROMs -> FrogFS -> patch superblock -> flash).
+
+Layout (flat): gw_retro_go_intflash.bin, sd_content/..., manifest.json
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+import zipfile
+
+EXCLUDE_TOP = {"covers", "cheats"}  # subordinate features, packed later
+ZIP_NAME = "web-artifacts.zip"
+# Neutral name on purpose — nothing here invites an end user. Safe even if someone
+# overwrites their SD with these: the firmware reads /cores, /bios, /roms from the
+# SD ROOT, but our SD content lives under sd_content/, so it's simply absent at root
+# (no content loads); and the on-device updater only flashes /retro-go_update.bin,
+# which we never ship → no flash, no brick.
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sd-content", required=True)
+    ap.add_argument("--blob", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--id", required=True)
+    ap.add_argument("--ref", required=True)
+    ap.add_argument("--sha", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--built-at", required=True)  # ISO8601; CI provides
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    zip_path = os.path.join(args.out, ZIP_NAME)
+
+    cores_dir = os.path.join(args.sd_content, "cores")
+    cores = sorted(
+        f[:-4]
+        for f in os.listdir(cores_dir)
+        if f.endswith(".bin") and not f.endswith("_defprops.bin")
+    ) if os.path.isdir(cores_dir) else []
+
+    # collect sd_content files (excluding covers/cheats), deterministic order
+    members = []  # (abs_path, arcname)
+    for root, dirs, files in os.walk(args.sd_content):
+        rel = os.path.relpath(root, args.sd_content)
+        if rel.split(os.sep)[0] in EXCLUDE_TOP:
+            dirs[:] = []
+            continue
+        dirs.sort()
+        for fn in sorted(files):
+            full = os.path.join(root, fn)
+            arc = os.path.join("sd_content", os.path.relpath(full, args.sd_content))
+            members.append((full, arc.replace(os.sep, "/")))
+
+    manifest = {
+        "id": args.id,
+        "ref": args.ref,
+        "sha": args.sha,
+        "model": args.model,
+        "sdCard": 0,
+        "superblock": True,
+        "builtAt": args.built_at,
+        "asset": ZIP_NAME,
+        "blob": "gw_retro_go_intflash.bin",
+        "cores": cores,
+        "fileCount": len(members),
+        "blobBytes": os.path.getsize(args.blob),
+    }
+
+    # fixed timestamp → reproducible-ish zips
+    zdate = (1980, 1, 1, 0, 0, 0)
+
+    def add_bytes(zf, arcname, data):
+        zi = zipfile.ZipInfo(arcname, date_time=zdate)
+        zi.compress_type = zipfile.ZIP_DEFLATED
+        zf.writestr(zi, data)
+
+    def add_file(zf, full, arcname):
+        zi = zipfile.ZipInfo(arcname, date_time=zdate)
+        zi.compress_type = zipfile.ZIP_DEFLATED
+        with open(full, "rb") as f:
+            zf.writestr(zi, f.read())
+
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        add_file(zf, args.blob, "gw_retro_go_intflash.bin")
+        for full, arc in members:
+            add_file(zf, full, arc)
+        add_bytes(zf, "manifest.json", json.dumps(manifest, indent=2).encode())
+
+    manifest["assetBytes"] = os.path.getsize(zip_path)
+    manifest["assetSha256"] = sha256(zip_path)
+    with open(os.path.join(args.out, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"{ZIP_NAME}: {manifest['assetBytes']} B ({manifest['fileCount']} content files)")
+    print(f"cores: {', '.join(cores)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/flasher/pack_bundle.py
+++ b/scripts/flasher/pack_bundle.py
@@ -52,7 +52,6 @@ def main():
     ap.add_argument("--id", required=True)
     ap.add_argument("--ref", required=True)
     ap.add_argument("--sha", required=True)
-    ap.add_argument("--model", required=True)
     ap.add_argument("--built-at", required=True)  # ISO8601; CI provides
     args = ap.parse_args()
 
@@ -85,7 +84,6 @@ def main():
         "id": args.id,
         "ref": args.ref,
         "sha": args.sha,
-        "model": args.model,
         "sdCard": 0,
         "superblock": True,
         "builtAt": args.built_at,

--- a/scripts/flasher/pack_bundle.py
+++ b/scripts/flasher/pack_bundle.py
@@ -24,6 +24,11 @@ import sys
 import zipfile
 
 EXCLUDE_TOP = {"covers", "cheats"}  # subordinate features, packed later
+# Firmware-update trigger files: the firmware_update bootloader flashes these
+# (firmware_update.c). They are SD-update plumbing — irrelevant to the web flasher
+# (we flash over USB) and the ONLY files in sd_content that could cause a flash if
+# someone merged the archive onto an SD card. Excluded so NOTHING here can flash.
+EXCLUDE_FILES = {"update_bank1.bin", "update_bank2.bin", "retro-go_update.bin"}
 ZIP_NAME = "web-artifacts.zip"
 # Neutral name on purpose — nothing here invites an end user. Safe even if someone
 # overwrites their SD with these: the firmware reads /cores, /bios, /roms from the
@@ -70,6 +75,8 @@ def main():
             continue
         dirs.sort()
         for fn in sorted(files):
+            if fn in EXCLUDE_FILES:
+                continue
             full = os.path.join(root, fn)
             arc = os.path.join("sd_content", os.path.relpath(full, args.sd_content))
             members.append((full, arc.replace(os.sep, "/")))


### PR DESCRIPTION
This is prep-work for the web-builder we briefly discussed in Discord. The point of this is to make it so one binary can serve frogfs being anywhere on extflash by patching it after generating the intflash blob. 

A FrogFS (SD_CARD=0) build mounts its read-only asset image at a compiled-in address (rg_frogfs.c: .addr = &__EXTFLASH_START__ = 0x90000000 + __EXTFLASH_OFFSET__). This bakes a small, magic-located GnwLayoutSuperblock into .rodata so a host tool can patch that offset (and optional extflash geometry) in a prebuilt binary — one binary serves any extflash offset, no rebuild/toolchain. Bank-agnostic (present in bank-1 and bank-2 builds); gated on SD_CARD=0 since that's where FrogFS lives.

- Core/Inc/retro-go/gw_layout_superblock.h: 32-byte struct (GWLB magic, version, frogfs_offset, geometry overrides, flags, crc32) + accessors.
- Core/Src/retro-go/gw_layout_superblock.c: struct (defaults baked from __EXTFLASH_OFFSET__, crc32=0) + validated accessors that fall back to the linker symbols when the struct is absent/invalid. CRC = crc32_le over [0,0x1C), the same idiom odroid_settings / tama save-states already use for struct integrity.
- Core/Src/retro-go/rg_frogfs.c: .addr = gw_layout_frogfs_addr() (the one line).
- Makefile: gw_layout_superblock.c in FROGFS_C_SOURCES.

A plain make is behaviorally identical to before: crc32=0 fails validation, so the firmware falls back to __EXTFLASH_START__ (which carries the same offset). Never bricks. Host patcher + spec: gnw-web-builder docs/BINARY_PATCHING.md.