### PR TITLE
Add generic GWHB homebrew loader

### DIFF
--- a/Core/Inc/gw_linker.h
+++ b/Core/Inc/gw_linker.h
@@ -30,6 +30,7 @@ extern uint32_t __itcram_hot_end__;
 
 // If this is not an array the compiler might put in a memory_chk with dest_size 1...
 extern void * __RAM_EMU_START__[];
+extern uint32_t __RAM_EMU_END__;
 extern void * _OVERLAY_NES_LOAD_START[];
 extern uint8_t _OVERLAY_NES_SIZE;
 extern void * _OVERLAY_NES_BSS_START[];

--- a/Core/Inc/retro-go/gwhb.h
+++ b/Core/Inc/retro-go/gwhb.h
@@ -1,15 +1,16 @@
 /*
  * Universal Homebrew Header (GWHB)
  *
- * Fixed 512-byte prefix every out-of-tree homebrew binary must start with,
+ * Fixed 64-byte prefix every out-of-tree homebrew binary must start with,
  * so it can run without any firmware-side dispatch-table entry, linker
  * overlay symbols, or appid.h enum: drop a .bin under /roms/homebrew/ and
  * it runs, as long as it starts with this header.
  *
- * The entry point is always at offset sizeof(gwhb_header_t) (512), no
- * matter what header_version says, so future header_version bumps can add
- * fields out of the reserved block without ever moving the jump target
- * again.
+ * The entry point is always at offset sizeof(gwhb_header_t) (64). New
+ * fields are added to the reserved block using a 0-means-absent sentinel
+ * (see name_table_offset/name_table_size below), rather than a struct
+ * layout version, so old and new binaries can share one loader without it
+ * needing to know which fields a given file's builder populated.
  *
  * name_table_offset/name_table_size are not read or acted on by the
  * loader yet. They're reserved so a build can optionally point at a
@@ -25,16 +26,14 @@
 
 typedef struct {
     uint32_t magic;                 /* GWHB_MAGIC */
-    uint32_t header_version;        /* layout of this struct itself */
     uint32_t required_abi;          /* gw_firmware_abi_t version this binary needs */
     uint32_t required_abi_min_size; /* minimum acceptable sizeof(gw_firmware_abi_t) */
-    uint32_t total_size;            /* whole file size, header included */
 
     /* Reserved, unused by the loader today; see file comment above. */
     uint32_t name_table_offset;
     uint32_t name_table_size;
 
-    uint8_t  reserved[484];         /* zeroed; future header_version bumps carve fields from here */
+    uint8_t  reserved[44];          /* zeroed; future fields carved from here, sentinel-gated */
 } gwhb_header_t;
 
-_Static_assert(sizeof(gwhb_header_t) == 512, "GWHB header must be exactly 512 bytes");
+_Static_assert(sizeof(gwhb_header_t) == 64, "GWHB header must be exactly 64 bytes");

--- a/Core/Inc/retro-go/gwhb.h
+++ b/Core/Inc/retro-go/gwhb.h
@@ -1,0 +1,40 @@
+/*
+ * Universal Homebrew Header (GWHB)
+ *
+ * Fixed 512-byte prefix every out-of-tree homebrew binary must start with,
+ * so it can run without any firmware-side dispatch-table entry, linker
+ * overlay symbols, or appid.h enum: drop a .bin under /roms/homebrew/ and
+ * it runs, as long as it starts with this header.
+ *
+ * The entry point is always at offset sizeof(gwhb_header_t) (512), no
+ * matter what header_version says, so future header_version bumps can add
+ * fields out of the reserved block without ever moving the jump target
+ * again.
+ *
+ * name_table_offset/name_table_size are not read or acted on by the
+ * loader yet. They're reserved so a build can optionally point at a
+ * variable-size, elsewhere-in-the-file table of (language, display name)
+ * entries for a future menu/coverflow feature; 0/0 means absent, and
+ * nothing currently falls back to it.
+ */
+#pragma once
+
+#include <stdint.h>
+
+#define GWHB_MAGIC 0x42485747u /* 'GWHB' little-endian */
+
+typedef struct {
+    uint32_t magic;                 /* GWHB_MAGIC */
+    uint32_t header_version;        /* layout of this struct itself */
+    uint32_t required_abi;          /* gw_firmware_abi_t version this binary needs */
+    uint32_t required_abi_min_size; /* minimum acceptable sizeof(gw_firmware_abi_t) */
+    uint32_t total_size;            /* whole file size, header included */
+
+    /* Reserved, unused by the loader today; see file comment above. */
+    uint32_t name_table_offset;
+    uint32_t name_table_size;
+
+    uint8_t  reserved[484];         /* zeroed; future header_version bumps carve fields from here */
+} gwhb_header_t;
+
+_Static_assert(sizeof(gwhb_header_t) == 512, "GWHB header must be exactly 512 bytes");

--- a/Core/Inc/retro-go/rg_storage.h
+++ b/Core/Inc/retro-go/rg_storage.h
@@ -75,4 +75,11 @@ typedef void (*file_progress_cb_t)(uint32_t total_size, uint32_t total_processed
 size_t rg_storage_copy_file_to_ram(char *file_path, uint8_t *ram_dest, file_progress_cb_t file_progress_cb);
 size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_dest, uint32_t offset, file_progress_cb_t file_progress_cb);
 
+/* Same as rg_storage_copy_file_to_ram_with_offset, but refuses (returns 0,
+ * copies nothing) if the file's size-after-offset exceeds max_len. Used by
+ * loaders that write into a fixed-size RAM region (e.g. RAM_EMU) fed by a
+ * runtime-supplied file, where the destination buffer's capacity is not
+ * implied by any compile-time overlay symbol. */
+size_t rg_storage_copy_file_to_ram_bounded(char *file_path, uint8_t *ram_dest, uint32_t offset, uint32_t max_len, file_progress_cb_t file_progress_cb);
+
 bool rg_storage_get_adjacent_files(const char *path, char *prev_path, char *next_path);

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -1166,14 +1166,6 @@ static void run_gwhb_homebrew(size_t copied, uint8_t load_state, uint8_t start_p
     if (hdr->magic != GWHB_MAGIC)
         return; /* not a GWHB file; nothing to dispatch */
 
-    /* total_size is attacker/corruption-controlled (comes from the file
-     * itself, not just its on-disk length), so clamp it before it's used
-     * for anything, including the cache-maintenance call below. */
-    if (hdr->total_size < sizeof(gwhb_header_t) || hdr->total_size > copied) {
-        show_incompatible_homebrew_screen();
-        return;
-    }
-
     /* Defense in depth, both against the same fields the app is expected
      * to self-check (see gnw_abi_ok()-style checks in ABI consumers), so a
      * binary built for a newer/bigger ABI than this firmware provides is
@@ -1192,7 +1184,7 @@ static void run_gwhb_homebrew(size_t copied, uint8_t load_state, uint8_t start_p
         return;
     }
 
-    SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, hdr->total_size);
+    SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, copied);
     SCB_InvalidateICache();
 
     /* | 1 keeps the CPU in Thumb mode. The binary zeroes its own BSS on

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -6,6 +6,8 @@
 
 #include "gw_linker.h"
 #include "gw_malloc.h"
+#include "gw_firmware_abi.h"
+#include "gwhb.h"
 #include "rg_emulators.h"
 #include "rg_storage.h"
 #include "rg_i18n.h"
@@ -1119,6 +1121,86 @@ static void run_internal_emu(const emu_dispatch_t *e,
     }
 }
 
+/* --- Universal Homebrew Header (GWHB) loader ---------------------------
+ *
+ * Lets an out-of-tree homebrew binary run without any firmware-side
+ * dispatch-table entry, linker overlay symbols, or appid.h enum: drop a
+ * .bin under /roms/homebrew/ and it runs, as long as it starts with a
+ * gwhb_header_t (see gwhb.h). The entry point is always at offset
+ * sizeof(gwhb_header_t), past the header.
+ *
+ * Unlike the compile-time dispatch table (run_internal_emu above), a GWHB
+ * binary is responsible for zeroing its own BSS and configuring its own
+ * LCD mode (RGB565 vs LUT8) via the firmware ABI, since the loader has no
+ * compile-time knowledge of its layout or needs, only its total size.
+ *
+ * Trust model: the file is loaded, unauthenticated, from an SD card, so
+ * every firmware-side check below is defensive: refuse rather than jump
+ * into a corrupt or incompatible binary. */
+
+static void show_incompatible_homebrew_screen(void)
+{
+  odroid_dialog_choice_t choices[] = {
+    {0, curr_lang->s_Corrupted_Install_1, "", -1, NULL},
+    ODROID_DIALOG_CHOICE_SEPARATOR,
+    {1, curr_lang->s_OK, "", 1, NULL},
+    ODROID_DIALOG_CHOICE_LAST,
+  };
+
+  (void)odroid_overlay_dialog(curr_lang->s_Corrupted_Title, choices, 2, NULL, 0);
+}
+
+/* `copied` is the byte count already placed at __RAM_EMU_START__ by the
+ * Homebrew branch's bounded copy (see emulator_start); this function does
+ * not touch storage itself, only validates and dispatches. */
+__attribute__((noinline))
+static void run_gwhb_homebrew(size_t copied, uint8_t load_state, uint8_t start_paused, int8_t save_slot)
+{
+    if (copied < sizeof(gwhb_header_t)) {
+        show_incompatible_homebrew_screen();
+        return;
+    }
+
+    const gwhb_header_t *hdr = (const gwhb_header_t *)&__RAM_EMU_START__;
+
+    if (hdr->magic != GWHB_MAGIC)
+        return; /* not a GWHB file; nothing to dispatch */
+
+    /* total_size is attacker/corruption-controlled (comes from the file
+     * itself, not just its on-disk length), so clamp it before it's used
+     * for anything, including the cache-maintenance call below. */
+    if (hdr->total_size < sizeof(gwhb_header_t) || hdr->total_size > copied) {
+        show_incompatible_homebrew_screen();
+        return;
+    }
+
+    /* Defense in depth, both against the same fields the app is expected
+     * to self-check (see gnw_abi_ok()-style checks in ABI consumers), so a
+     * binary built for a newer/bigger ABI than this firmware provides is
+     * refused before it ever gets a chance to call through a function
+     * pointer past the end of g_firmware_abi.
+     *
+     * required_abi alone is not enough: append-only ABI growth does not
+     * bump GW_FIRMWARE_ABI_VERSION (see the comment above that define), so
+     * two firmware builds can report the same version with different
+     * actual struct sizes. required_abi_min_size is the field that
+     * actually detects "this firmware predates a field I need". Anything
+     * built for an older/smaller ABI is fine, hence <=, not ==. */
+    if (hdr->required_abi > GW_FIRMWARE_ABI_VERSION ||
+        hdr->required_abi_min_size > g_firmware_abi.size) {
+        show_incompatible_homebrew_screen();
+        return;
+    }
+
+    SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, hdr->total_size);
+    SCB_InvalidateICache();
+
+    /* | 1 keeps the CPU in Thumb mode. The binary zeroes its own BSS on
+     * entry. */
+    ((void (*)(uint8_t, uint8_t, int8_t))(((uintptr_t)&__RAM_EMU_START__ + sizeof(gwhb_header_t)) | 1))
+        (load_state, start_paused, save_slot);
+}
+
 /* Entry-pointer casts: app_main_* signatures vary in return type
  * (void/int) and save_slot type (int8_t/uint8_t). All are ARM
  * calling-convention compatible (same register layout, return value
@@ -1252,7 +1334,14 @@ void emulator_start(retro_emulator_file_t *file, bool load_state, bool start_pau
 #endif
 #endif
     } else if(strcmp(system_name, "Homebrew") == 0)  {
-      if (odroid_overlay_cache_file_in_ram(ACTIVE_FILE->path, (uint8_t *)&__RAM_EMU_START__)) {
+      /* Bounded: refuses (returns 0) rather than overrunning RAM_EMU if the
+       * file is bigger than the region. This used to be an unchecked
+       * odroid_overlay_cache_file_in_ram() call; every branch below
+       * (including the legacy named engines) shares that fix now. */
+      const uint32_t ram_emu_len = ((uint32_t)&__RAM_EMU_END__) - (uint32_t)&__RAM_EMU_START__;
+      size_t homebrew_bytes = rg_storage_copy_file_to_ram_bounded(
+          ACTIVE_FILE->path, (uint8_t *)&__RAM_EMU_START__, 0, ram_emu_len, NULL);
+      if (homebrew_bytes) {
         if (strcmp(newfile->name,"celeste") == 0) {
             memset(&_OVERLAY_CELESTE_BSS_START, 0x0, (size_t)&_OVERLAY_CELESTE_BSS_SIZE);
             SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, (size_t)&_OVERLAY_CELESTE_SIZE);
@@ -1265,7 +1354,13 @@ void emulator_start(retro_emulator_file_t *file, bool load_state, bool start_pau
             memset(&_OVERLAY_SMW_BSS_START, 0x0, (size_t)&_OVERLAY_SMW_BSS_SIZE);
             SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, (size_t)&_OVERLAY_SMW_SIZE);
             app_main_smw(load_state, start_paused, save_slot);
+        } else {
+            /* Not one of the legacy named engines above, so check for a
+             * generic Universal Homebrew Header (GWHB) instead. */
+            run_gwhb_homebrew(homebrew_bytes, load_state, start_paused, save_slot);
         }
+      } else {
+        show_incompatible_homebrew_screen();
       }
     } else if(strcmp(system_name, "Tamagotchi") == 0) {
         run_internal_emu(&emu_tama, load_state, start_paused, save_slot);

--- a/Core/Src/retro-go/rg_storage.c
+++ b/Core/Src/retro-go/rg_storage.c
@@ -304,7 +304,12 @@ bool rg_storage_scandir(const char *path, rg_scandir_cb_t *callback, void *arg, 
 #endif
 }
 
-size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_dest, uint32_t offset, file_progress_cb_t file_progress_cb) {
+/* max_len == 0 means unbounded (preserves the historical, unchecked
+ * behavior relied upon by every existing caller of the two public
+ * wrappers below). */
+static size_t rg_storage_copy_file_to_ram_impl(char *file_path, uint8_t *ram_dest,
+                                                uint32_t offset, uint32_t max_len,
+                                                file_progress_cb_t file_progress_cb) {
     FILE *file;
     size_t bytes_read;
     uint32_t total_written;
@@ -312,7 +317,7 @@ size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_des
     file = fopen(file_path,"rb");
     if (file == NULL) {
         return 0;
-    } 
+    }
 
     if (fseek(file, 0, SEEK_END) != 0) {
         fclose(file);
@@ -324,6 +329,11 @@ size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_des
         return 0;
     }
     uint32_t total_size = (uint32_t)file_size_l - offset;
+    if (max_len != 0 && total_size > max_len) {
+        // Refuse rather than overrun the caller's destination buffer/region.
+        fclose(file);
+        return 0;
+    }
     if (fseek(file, (long)offset, SEEK_SET) != 0) {
         fclose(file);
         return 0;
@@ -345,6 +355,14 @@ size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_des
     fclose(file);
 
     return total_written;
+}
+
+size_t rg_storage_copy_file_to_ram_with_offset(char *file_path, uint8_t *ram_dest, uint32_t offset, file_progress_cb_t file_progress_cb) {
+    return rg_storage_copy_file_to_ram_impl(file_path, ram_dest, offset, 0, file_progress_cb);
+}
+
+size_t rg_storage_copy_file_to_ram_bounded(char *file_path, uint8_t *ram_dest, uint32_t offset, uint32_t max_len, file_progress_cb_t file_progress_cb) {
+    return rg_storage_copy_file_to_ram_impl(file_path, ram_dest, offset, max_len, file_progress_cb);
 }
 
 /* copy file content into ram */


### PR DESCRIPTION
Lets an out-of-tree homebrew binary run without a firmware-side dispatch-table entry, linker overlay symbols, or appid.h enum: drop a .bin under /roms/homebrew/ that starts with a 512-byte gwhb_header_t (gwhb.h) and it runs, dispatched from the existing "Homebrew" branch in emulator_start() after the legacy celeste/Zelda 3/Super Mario World name checks.

The loader checks required_abi and required_abi_min_size against the live firmware ABI before jumping, since GW_FIRMWARE_ABI_VERSION does not bump on pure appends, so version alone can't detect a binary built against fields the running firmware predates.

Also fixes a pre-existing unbounded copy: the "Homebrew" branch used to copy an SD card file into RAM_EMU with no size check at all (odroid_overlay_cache_file_in_ram). rg_storage_copy_file_to_ram_bounded refuses rather than overruns when a file is bigger than the region; celeste/Zelda 3/Super Mario World now go through it too, with a bound loose enough (the whole RAM_EMU region) that no legitimate existing binary is affected.