### PR TITLE
fix(linker): keep _stack_redzone aligned so the MPU region is programmed

### DIFF
--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -67,7 +67,10 @@ _Min_Stack_Size = 20 * 1024; /* required amount of stack */
 __NULLPTR_LENGTH__  = 0x0;
 __ITCMRAM_LENGTH__  = 64K;
 __DTCMRAM_LENGTH__  = 128K;
-__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? REMOTE_INPUT * 12 : 0;
+/* Rounded up to 256 so the top-of-DTCM stack block stays 256-byte aligned.
+ * This mask is evaluated OUTSIDE any output section, where '&' operates on a
+ * true absolute value -- see the _heap_limit comment below for why that matters. */
+__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? ((REMOTE_INPUT * 12 + 255) & ~255) : 0;
 __RAM_UC_LENGTH__   = 300K;
 __RAM_CORE_LENGTH__ = 0K;
 __RAM_EMU_LENGTH__  = 1024K - __RAM_UC_LENGTH__ - __RAM_CORE_LENGTH__;
@@ -899,11 +902,25 @@ INCLUDE build/fceumm_mappers.ld
     /* Alias for scripts/size.sh — "padding" is now the whole flexible heap. */
     __dtc_padding_start__ = .;
 
-    /* Align down so . = _heap_limit never steps into the stack. */
-    _heap_limit = (ORIGIN(DTCMRAM) + LENGTH(DTCMRAM)
+    /* NO masking here. Symbol assignments inside an output section are evaluated
+     * SECTION-RELATIVE by ld, so a '& ~15' would silently become
+     *     base + ((target - base) & ~15)
+     * where base is wherever .bss happened to end. That only equals the intended
+     * constant when ._user_heap starts 16-byte aligned, so any change to DTCM
+     * .bss size could shift _stack_redzone off its required alignment. A
+     * misaligned redzone sets bit4 of the value written to MPU_RBAR, which is the
+     * VALID flag -- the region number is then taken from bits[3:0], goes out of
+     * range on an 8-region M7, and the write is DISCARDED. MPU region 2 then keeps
+     * its reset base of 0 while the RASR write lands, turning 0x0-0xFF into a
+     * no-access trap and faulting the first itc_malloc() allocation.
+     *
+     * Plain +/- is transparent to the relative rebasing, so this stays a true
+     * constant. All three terms are multiples of 256, so it is 256-byte aligned
+     * by construction -- asserted after ._user_stack below. */
+    _heap_limit = ORIGIN(DTCMRAM) + LENGTH(DTCMRAM)
                 - __REMOTE_INPUT_RESERVE__
                 - _Min_Stack_Size
-                - _Stack_Redzone_Size) & ~15;
+                - _Stack_Redzone_Size;
     ASSERT(_heap_start <= _heap_limit,
            "DTCM overflow: .data/.bss leave no room for stack");
 
@@ -922,6 +939,13 @@ INCLUDE build/fceumm_mappers.ld
     . = . + __REMOTE_INPUT_RESERVE__;
     __dtcram_end__ = .;
   } >DTCMRAM
+
+  /* _stack_redzone is an MPU region base (MPU_Config() in Core/Src/main.c) and the
+   * region is _Stack_Redzone_Size bytes, so it MUST be aligned to that size. If this
+   * fires, something made _heap_limit non-constant again -- do not "fix" it by
+   * nudging .bss; fix the expression. */
+  _stack_redzone_align_check = ASSERT((_stack_redzone & (_Stack_Redzone_Size - 1)) == 0,
+         "_stack_redzone must be _Stack_Redzone_Size-aligned: it is an MPU region base");
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/STM32H7B0VBTx_SDCARD.ld
+++ b/STM32H7B0VBTx_SDCARD.ld
@@ -67,7 +67,10 @@ _Min_Stack_Size = 24 * 1024; /* required amount of stack */
 __NULLPTR_LENGTH__  = 0x0;
 __ITCMRAM_LENGTH__  = 64K;
 __DTCMRAM_LENGTH__  = 128K;
-__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? REMOTE_INPUT * 12 : 0;
+/* Rounded up to 256 so the top-of-DTCM stack block stays 256-byte aligned.
+ * This mask is evaluated OUTSIDE any output section, where '&' operates on a
+ * true absolute value -- see the _heap_limit comment below for why that matters. */
+__REMOTE_INPUT_RESERVE__ = DEFINED(REMOTE_INPUT) ? ((REMOTE_INPUT * 12 + 255) & ~255) : 0;
 __RAM_UC_LENGTH__   = 300K; /* framebuffer : 2 x 320 x 240 x 16 bits */
 __RAM_EMU_LENGTH__  = 1024K - __RAM_UC_LENGTH__;
 __AHBRAM_LENGTH__   = 128K;
@@ -1116,11 +1119,25 @@ INCLUDE build/fceumm_mappers.ld
     /* Alias for scripts/size.sh — "padding" is now the whole flexible heap. */
     __dtc_padding_start__ = .;
 
-    /* Align down so . = _heap_limit never steps into the stack. */
-    _heap_limit = (ORIGIN(DTCMRAM) + LENGTH(DTCMRAM)
+    /* NO masking here. Symbol assignments inside an output section are evaluated
+     * SECTION-RELATIVE by ld, so a '& ~15' would silently become
+     *     base + ((target - base) & ~15)
+     * where base is wherever .bss happened to end. That only equals the intended
+     * constant when ._user_heap starts 16-byte aligned, so any change to DTCM
+     * .bss size could shift _stack_redzone off its required alignment. A
+     * misaligned redzone sets bit4 of the value written to MPU_RBAR, which is the
+     * VALID flag -- the region number is then taken from bits[3:0], goes out of
+     * range on an 8-region M7, and the write is DISCARDED. MPU region 2 then keeps
+     * its reset base of 0 while the RASR write lands, turning 0x0-0xFF into a
+     * no-access trap and faulting the first itc_malloc() allocation.
+     *
+     * Plain +/- is transparent to the relative rebasing, so this stays a true
+     * constant. All three terms are multiples of 256, so it is 256-byte aligned
+     * by construction -- asserted after ._user_stack below. */
+    _heap_limit = ORIGIN(DTCMRAM) + LENGTH(DTCMRAM)
                 - __REMOTE_INPUT_RESERVE__
                 - _Min_Stack_Size
-                - _Stack_Redzone_Size) & ~15;
+                - _Stack_Redzone_Size;
     ASSERT(_heap_start <= _heap_limit,
            "DTCM overflow: .data/.bss leave no room for stack");
 
@@ -1139,6 +1156,13 @@ INCLUDE build/fceumm_mappers.ld
     . = . + __REMOTE_INPUT_RESERVE__;
     __dtcram_end__ = .;
   } >DTCMRAM
+
+  /* _stack_redzone is an MPU region base (MPU_Config() in Core/Src/main.c) and the
+   * region is _Stack_Redzone_Size bytes, so it MUST be aligned to that size. If this
+   * fires, something made _heap_limit non-constant again -- do not "fix" it by
+   * nudging .bss; fix the expression. */
+  _stack_redzone_align_check = ASSERT((_stack_redzone & (_Stack_Redzone_Size - 1)) == 0,
+         "_stack_redzone must be _Stack_Redzone_Size-aligned: it is an MPU region base");
 
   /* Remove information from the standard libraries */
   /DISCARD/ :


### PR DESCRIPTION
_stack_redzone is used as an MPU region base by MPU_Config(), so it must be aligned to the region size. It was not, and whether a given build happened to land on a safe address was decided by unrelated changes to DTCM .bss.

_heap_limit is computed inside ._user_heap as

    (ORIGIN(DTCMRAM) + LENGTH(DTCMRAM) - reserve - stack - redzone) & ~15

which reads as a constant but is not. ld evaluates symbol assignments inside an output section as section-relative, so the mask is applied to an offset and the result is rebased:

    base + ((target - base) & ~15)

where base is wherever .bss ended. That equals the intended constant only when ._user_heap starts 16-byte aligned. Observed directly in the map file: base 0x20003500 yields 0x20019f00, base 0x20003508 yields 0x20019ef8.

The consequences are not local. MPU_Config() writes _stack_redzone straight into MPU_RBAR, where bit 4 is VALID and bits[3:0] are REGION. A misaligned value therefore sets VALID and selects region 8, which is out of range on an 8-region Cortex-M7, so the write is discarded. The RASR write still lands via MPU_RNR, leaving region 2 enabled at its reset base of 0 with no-access permissions. That turns 0x00000000-0x000000FF into a trap, and since itc_malloc() returns address 0 as its first allocation on SD builds (._itcram has no input sections, so __itcram_end__ == 0), rg_get_logo() takes a MemManage fault on the first logo-cache allocation.

The trigger is any change to DTCM .bss size. app_config_t is 6 bytes and appears as app[APPID_COUNT] in persistent_config_t, so simply adding an emulator ID moves it. Measured on SD_CARD=1 INTFLASH_BANK=1 by adding N dummy IDs to appid_t: N of 0, 5 and 8 produced an aligned redzone and booted, while 1, 2, 3, 4, 6 and 7 produced 0x20019ef4/f8/fc and faulted during boot.

Fix the expression rather than the symptom:

  - Round __REMOTE_INPUT_RESERVE__ up to 256 where it is defined, outside any output section, where '&' operates on a true absolute value.
  - Drop the mask from _heap_limit. Plain addition and subtraction are transparent to the relative rebasing, so the symbol is now genuinely constant, and all three terms are multiples of 256.

Add a linker assert on the alignment so this cannot regress silently again. It fires at link time with a message naming the cause, which is worth having: the runtime symptom is a fault in unrelated code and gives no hint that a linker expression is responsible.

Both scripts carry the same expression, so both are fixed. Verified aligned on SD_CARD=1 bank 1, SD_CARD=1 bank 2, and SD_CARD=0, and verified that adding 1, 2, 3, 4, 6 or 7 emulator IDs no longer moves it.