### PR TITLE
Enable D2/AHB SRAM clock (DATA_IN_D2_SRAM), fixing boot fault on hardware

### DIFF
--- a/Core/Src/system_stm32h7xx.c
+++ b/Core/Src/system_stm32h7xx.c
@@ -93,7 +93,10 @@
 
 /************************* Miscellaneous Configuration ************************/
 /*!< Uncomment the following line if you need to use initialized data in D2 domain SRAM (AHB SRAM) */
-/* #define DATA_IN_D2_SRAM */
+/* Required: the link scripts place .persistent/.data/.bss and the newlib heap
+   in AHB SRAM (0x30000000). Without this, RCC->AHB2ENR stays 0 and crt0's
+   .data copy bus-faults before main -- invisible under gwemu, dead on silicon. */
+#define DATA_IN_D2_SRAM
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */


### PR DESCRIPTION
Enable D2/AHB SRAM clock (DATA_IN_D2_SRAM), fixing boot fault on hardware

The link scripts place .persistent, .data, .bss and the newlib heap in AHB SRAM at 0x30000000, and STM32H7B0VBTx_SDCARD.ld says so explicitly: "Requires DATA_IN_D2_SRAM so SystemInit enables AHB SRAM before crt0 copies .data / zeroes .bss". That define was never actually enabled, so RCC->AHB2ENR stayed 0 and the region was unclocked.

On silicon crt0's .data copy then took a bus fault that escalated to a HardFault (CFSR=0x8600, HFSR=0x40000000 FORCED, ABFSR=0x308 AXIM), surfacing at the first printf() in main(). The screen stayed blank because BSOD() runs before the LCD is initialised, leaving the firmware spinning in buttons_get().

gwemu treats AHB SRAM as plain memory regardless of clock gating, so the failure was invisible under emulation and only appeared on the device.